### PR TITLE
Updated pom to use metric-consumer 0.1.0

### DIFF
--- a/central-query/pom.xml
+++ b/central-query/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <zapp.version>0.0.16</zapp.version>
-        <metric-consumer.version>0.0.15</metric-consumer.version>
+        <metric-consumer.version>0.1.0</metric-consumer.version>
         <jersey.version>1.15</jersey.version>
         <junit.version>4.11</junit.version>
         <spring.version>3.2.1.RELEASE</spring.version>


### PR DESCRIPTION
Part of the fixes for https://jira.zenoss.com/browse/CC-575

Other PRs required to address CC-575 include:
zenoss/zenoss.metric.consumer#62 (changes incorporated in the 0.1.0 release)
control-center/serviced#1710
https://github.com/control-center/serviced/pull/1710