### PR TITLE
ZEN-18194: remove UNKNOWN status for calculated (rpn) series

### DIFF
--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriter.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriter.java
@@ -117,9 +117,6 @@ public class JacksonResultsWriter {
     private QueryStatus getQueryStatus(MetricSpecification query, Buckets<IHasShortcut> buckets) {
         MetricKey key = MetricKey.fromValue(query);
         QueryStatus result = buckets.getQueryStatus(key);
-        if (null == result) {
-            result = new QueryStatus(QueryStatus.QueryStatusEnum.UNKNOWN, String.format("Unknown query status for query %s", query.toString()));
-        }
         return result;
     }
 

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/metric/impl/MetricService.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/metric/impl/MetricService.java
@@ -90,7 +90,7 @@ public class MetricService implements MetricServiceAPI {
                 if (spec.getMetric() != null) {
                     result.add(spec);
                 } else {
-                    log.warn("skipping metricSpecification {} - no metric value found.", spec.getNameOrMetric());
+                    log.debug("MetricFilter: filtering out metricSpecification {} - no metric value found.", spec.getNameOrMetric());
                 }
             }
         }


### PR DESCRIPTION
Remove 'unknown' status for RPN expression (calculated) series (in JacksonResultsWriter.java).

Bonus fix (on MetricService.java): change log level from warn to debug on message that indicates filter is doing its job (not really a warning condition, and too chatty for into).