### PR TITLE
ZEN-18713: Logical Node Save button will not work in IE11

### DIFF
--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -29,8 +29,8 @@ var visualization,
     }
 
     if (typeof String.prototype.startsWith !== 'function') {
-        String.prototype.startsWith = function(str) {
-            return this.slice(0, str.length) === str;
+        String.prototype.startsWith = function(prefix) {
+            return this.indexOf(prefix) === 0;
         };
     }
 


### PR DESCRIPTION
required to check for "undefined" or give it to indexOf function 