### PR TITLE
ensure query status is not null.

### DIFF
--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBClient.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBClient.java
@@ -83,6 +83,9 @@ public class OpenTSDBClient {
                 if (null != resultArray && resultArray.length > 0) {
                     queryStatus = new QueryStatus(QueryStatus.QueryStatusEnum.SUCCESS, "");
                 }
+                if (null == queryStatus) {
+                    queryStatus = new QueryStatus(QueryStatus.QueryStatusEnum.WARNING, "OpenTSDB query was successful, but no data was returned.");
+                }
             }
         } catch (ClientProtocolException e) {
             log.error("ClientProtocolException executing and processing query: {}", e.getMessage());

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBQueryReturn.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBQueryReturn.java
@@ -21,7 +21,11 @@ public class OpenTSDBQueryReturn {
 
     public OpenTSDBQueryReturn(OpenTSDBQueryResult[] results, QueryStatus status) {
         this.results = ImmutableList.copyOf(results);
-        this.status = status;
+        if (null == status) {
+            this.status = new QueryStatus();
+        } else {
+            this.status = status;
+        }
     }
 
     public List<OpenTSDBQueryResult> getResults() {


### PR DESCRIPTION
This is the basic fix for ZEN_19679 - It'll get UCS-PM unblocked.
To-do (for Monday): 
* add logging if the status is defaulted in the OpenTSDBQueryReturn constructor
* use mocking framework to add unit test for this case (200 return, no data).