### PR TITLE
preserve overlay toggle status through graph refresh

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -1120,7 +1120,8 @@
                     'key' : key,
                     'color' : info.color,
                     'fill' : info.fill,
-                    'values' : []
+                    'values' : [],
+                    'disabled' : info.disabled
                 };
 
                 series.datapoints.forEach(function(datapoint){
@@ -1158,15 +1159,20 @@
 
             // add overlays
             if (this.overlays.length && plots.length && plots[0].values.length) {
-                for (i in this.overlays) {
-                    overlay = this.overlays[i];
+                this.overlays.forEach(function(overlay){
+                    // if disabled is undefined, default to true, otherwise
+                    // use the disabled value
+                    var isDisabled = "disabled" in overlay ? overlay.disabled : true;
                     // get the date range
                     firstMetric = plots[0];
                     plot = {
                         'key' : overlay.legend + "*",
-                        'disabled' : true,
+                        'disabled' : isDisabled,
                         'values' : [],
-                        'color' : overlay.color
+                        'color' : overlay.color,
+                        // store original overlay object
+                        // on this plot
+                        'overlay': overlay
                     };
                     minDate = firstMetric.values[0].x;
                     maxDate = firstMetric.values[firstMetric.values.length - 1].x;
@@ -1184,7 +1190,7 @@
                         });
                     }
                     plots.push(plot);
-                }
+                });
             }
 
             return plots;

--- a/central-query/src/main/js/visualization/src/charts/area.js
+++ b/central-query/src/main/js/visualization/src/charts/area.js
@@ -90,7 +90,9 @@
             // overlays disabled state so they
             // can persist through graph refresh
             model.dispatch.on("stateChange", function(state){
-                model.legendState = state.disabled;
+                if(model.legendState){
+                    model.legendState = state.disabled;
+                }
             });
 
             chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);

--- a/central-query/src/main/js/visualization/src/charts/area.js
+++ b/central-query/src/main/js/visualization/src/charts/area.js
@@ -43,18 +43,11 @@
                 model.yDomain(chart.calculateYDomain(chart.miny, chart.maxy, data));
             }
 
-            // find out which series are disabled or not
-            var disabled = {};
-            chart.svg.selectAll("g.nv-series")
-                .each(function(d) {
-                    disabled[d.key] = d.disabled;
-                });
-
-            // make sure when we update we preserve the disabled behavior
-            chart.plots.forEach(function(d) {
-                if (disabled[d.key] === true) {
-                    d.disabled = true;
-                }
+            // copy series disabled flags to plots
+            // so that graph will preserve series
+            // toggle state
+            chart.plots.forEach(function(plot, i){
+                plot.disabled = model.legendState[i];
             });
 
             chart.svg.datum(chart.plots)
@@ -92,6 +85,13 @@
             model.useInteractiveGuideline(true);
             model.showControls(false);
             model.duration(0);
+
+            // on legend state change, update any
+            // overlays disabled state so they
+            // can persist through graph refresh
+            model.dispatch.on("stateChange", function(state){
+                model.legendState = state.disabled;
+            });
 
             chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);
             // since were controlling labels ourselves,

--- a/central-query/src/main/js/visualization/src/charts/line.js
+++ b/central-query/src/main/js/visualization/src/charts/line.js
@@ -56,26 +56,21 @@
         },
 
         update : function(chart, data) {
-            var _chart = chart.closure;
+            var _chart = chart.closure,
+                model = _chart.model();
 
-            chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);
+            chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, model.xAxis);
 
             // if a max or min y are set
             if (chart.maxy !== undefined || chart.miny !== undefined) {
-                _chart.model().yDomain(chart.calculateYDomain(chart.miny, chart.maxy, data));
+                model.yDomain(chart.calculateYDomain(chart.miny, chart.maxy, data));
             }
-            // find out which series are disabled or not
-            var disabled = {};
-            chart.svg.selectAll("g.nv-series")
-                .each(function(d) {
-                    disabled[d.key] = d.disabled;
-                });
 
-            // make sure when we update we preserve the disabled behavior
-            chart.plots.forEach(function(d) {
-                if (disabled[d.key] === true) {
-                    d.disabled = true;
-                }
+            // copy series disabled flags to plots
+            // so that graph will preserve series
+            // toggle state
+            chart.plots.forEach(function(plot, i){
+                plot.disabled = model.legendState[i];
             });
 
             chart.svg
@@ -96,6 +91,13 @@
 
             model.useInteractiveGuideline(true);
             model.duration(0);
+
+            // on legend state change, update any
+            // overlays disabled state so they
+            // can persist through graph refresh
+            model.dispatch.on("stateChange", function(state){
+                model.legendState = state.disabled;
+            });
 
             chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);
             // since were controlling labels ourselves,

--- a/central-query/src/main/js/visualization/src/charts/line.js
+++ b/central-query/src/main/js/visualization/src/charts/line.js
@@ -70,7 +70,9 @@
             // so that graph will preserve series
             // toggle state
             chart.plots.forEach(function(plot, i){
-                plot.disabled = model.legendState[i];
+                if(model.legendState){
+                    plot.disabled = model.legendState[i];
+                }
             });
 
             chart.svg

--- a/central-query/src/main/resources/api/charts/area.js
+++ b/central-query/src/main/resources/api/charts/area.js
@@ -90,7 +90,9 @@
             // overlays disabled state so they
             // can persist through graph refresh
             model.dispatch.on("stateChange", function(state){
-                model.legendState = state.disabled;
+                if(model.legendState){
+                    model.legendState = state.disabled;
+                }
             });
 
             chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);

--- a/central-query/src/main/resources/api/charts/area.js
+++ b/central-query/src/main/resources/api/charts/area.js
@@ -43,18 +43,11 @@
                 model.yDomain(chart.calculateYDomain(chart.miny, chart.maxy, data));
             }
 
-            // find out which series are disabled or not
-            var disabled = {};
-            chart.svg.selectAll("g.nv-series")
-                .each(function(d) {
-                    disabled[d.key] = d.disabled;
-                });
-
-            // make sure when we update we preserve the disabled behavior
-            chart.plots.forEach(function(d) {
-                if (disabled[d.key] === true) {
-                    d.disabled = true;
-                }
+            // copy series disabled flags to plots
+            // so that graph will preserve series
+            // toggle state
+            chart.plots.forEach(function(plot, i){
+                plot.disabled = model.legendState[i];
             });
 
             chart.svg.datum(chart.plots)
@@ -92,6 +85,13 @@
             model.useInteractiveGuideline(true);
             model.showControls(false);
             model.duration(0);
+
+            // on legend state change, update any
+            // overlays disabled state so they
+            // can persist through graph refresh
+            model.dispatch.on("stateChange", function(state){
+                model.legendState = state.disabled;
+            });
 
             chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);
             // since were controlling labels ourselves,

--- a/central-query/src/main/resources/api/charts/line.js
+++ b/central-query/src/main/resources/api/charts/line.js
@@ -56,26 +56,21 @@
         },
 
         update : function(chart, data) {
-            var _chart = chart.closure;
+            var _chart = chart.closure,
+                model = _chart.model();
 
-            chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);
+            chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, model.xAxis);
 
             // if a max or min y are set
             if (chart.maxy !== undefined || chart.miny !== undefined) {
-                _chart.model().yDomain(chart.calculateYDomain(chart.miny, chart.maxy, data));
+                model.yDomain(chart.calculateYDomain(chart.miny, chart.maxy, data));
             }
-            // find out which series are disabled or not
-            var disabled = {};
-            chart.svg.selectAll("g.nv-series")
-                .each(function(d) {
-                    disabled[d.key] = d.disabled;
-                });
 
-            // make sure when we update we preserve the disabled behavior
-            chart.plots.forEach(function(d) {
-                if (disabled[d.key] === true) {
-                    d.disabled = true;
-                }
+            // copy series disabled flags to plots
+            // so that graph will preserve series
+            // toggle state
+            chart.plots.forEach(function(plot, i){
+                plot.disabled = model.legendState[i];
             });
 
             chart.svg
@@ -96,6 +91,13 @@
 
             model.useInteractiveGuideline(true);
             model.duration(0);
+
+            // on legend state change, update any
+            // overlays disabled state so they
+            // can persist through graph refresh
+            model.dispatch.on("stateChange", function(state){
+                model.legendState = state.disabled;
+            });
 
             chart.updateXLabels(data.startTimeActual * 1000, data.endTimeActual * 1000, _chart.model().xAxis);
             // since were controlling labels ourselves,

--- a/central-query/src/main/resources/api/charts/line.js
+++ b/central-query/src/main/resources/api/charts/line.js
@@ -70,7 +70,9 @@
             // so that graph will preserve series
             // toggle state
             chart.plots.forEach(function(plot, i){
-                plot.disabled = model.legendState[i];
+                if(model.legendState){
+                    plot.disabled = model.legendState[i];
+                }
             });
 
             chart.svg

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -2388,7 +2388,8 @@ if (typeof exports !== 'undefined') {
                     'key' : key,
                     'color' : info.color,
                     'fill' : info.fill,
-                    'values' : []
+                    'values' : [],
+                    'disabled' : info.disabled
                 };
 
                 series.datapoints.forEach(function(datapoint){
@@ -2426,15 +2427,20 @@ if (typeof exports !== 'undefined') {
 
             // add overlays
             if (this.overlays.length && plots.length && plots[0].values.length) {
-                for (i in this.overlays) {
-                    overlay = this.overlays[i];
+                this.overlays.forEach(function(overlay){
+                    // if disabled is undefined, default to true, otherwise
+                    // use the disabled value
+                    var isDisabled = "disabled" in overlay ? overlay.disabled : true;
                     // get the date range
                     firstMetric = plots[0];
                     plot = {
                         'key' : overlay.legend + "*",
-                        'disabled' : true,
+                        'disabled' : isDisabled,
                         'values' : [],
-                        'color' : overlay.color
+                        'color' : overlay.color,
+                        // store original overlay object
+                        // on this plot
+                        'overlay': overlay
                     };
                     minDate = firstMetric.values[0].x;
                     maxDate = firstMetric.values[firstMetric.values.length - 1].x;
@@ -2452,7 +2458,7 @@ if (typeof exports !== 'undefined') {
                         });
                     }
                     plots.push(plot);
-                }
+                });
             }
 
             return plots;


### PR DESCRIPTION
a bit o' context:

the problem is that when the graph updates, it forgets if thresholds and/or projections were toggled on or off. The default for these "overlays" is off, so they always turn back off.

`chart.plots` is a the list of all series's to display on the chart. this includes overlays (projections and thresholds) as well as regular ol metrics. `plots` is bound to the chart, so when the user interacts with it, the toggle state (`disabled` flag) is bound to the appropriate object in the `plots` array.  

`plots` is recreated with each graph update, so that toggle stage gets cleared, hence the problem.  

Fortunately, the graph emits an event when the toggle state changes, so we can store that state and after graph update, apply that state to all series's in `plots`.

also, note that the compiled/built code is checked into the repo so many of the files changes can be ignored.