### PR TITLE
draw separate series for each overlay value

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -1205,9 +1205,14 @@
          *          chart library.
          */
         __processResult: function (request, data) {
-            var plots, i, overlay, minDate, maxDate, plot, k, firstMetric;
+            var plots, firstMetric, minDate, maxDate;
 
             plots = this.__processResultAsSeries(request, data);
+
+            // get the date range
+            firstMetric = plots[0];
+            minDate = firstMetric.values[0].x;
+            maxDate = firstMetric.values[firstMetric.values.length - 1].x;
 
             // add overlays
             if (this.overlays.length && plots.length && plots[0].values.length) {
@@ -1215,33 +1220,46 @@
                     // if disabled is undefined, default to true, otherwise
                     // use the disabled value
                     var isDisabled = "disabled" in overlay ? overlay.disabled : true;
-                    // get the date range
-                    firstMetric = plots[0];
-                    plot = {
-                        'key': overlay.legend + "*",
-                        'disabled': isDisabled,
-                        'values': [],
-                        'color': overlay.color,
-                        // store original overlay object
-                        // on this plot
-                        'overlay': overlay
-                    };
-                    minDate = firstMetric.values[0].x;
-                    maxDate = firstMetric.values[firstMetric.values.length - 1].x;
-                    for (k = 0; k < overlay.values.length; k += 1) {
+
+                    // if the overlay includes 2 values, we assume
+                    // it is a minmax threshold
+                    var isMinMax = overlay.values.length === 2 ? true: false;
+
+                    // NOTE: each value in an overlay is used to draw a horizontal
+                    // line at that y coordinate.
+                    overlay.values.sort().forEach(function(value, k){
+                        var plot = {
+                            'key': overlay.legend + "*",
+                            'disabled': isDisabled,
+                            'values': [],
+                            'color': overlay.color,
+                            // store original overlay object
+                            // on this plot
+                            'overlay': overlay
+                        };
 
                         // create a line by putting a point at the start and a point
                         // at the end
                         plot.values.push({
                             x: minDate,
-                            y: overlay.values[k]
+                            y: value
                         });
                         plot.values.push({
                             x: maxDate,
-                            y: overlay.values[k]
+                            y: value
                         });
-                    }
-                    plots.push(plot);
+
+                        // if this is a minmax threshold, we want
+                        // to label the key as such
+                        if(isMinMax){
+                            if(k === 0){
+                                plot.key = overlay.legend +" min*";
+                            } else if(k === 1){
+                                plot.key = overlay.legend +" max*";
+                            }
+                        }
+                        plots.push(plot);
+                    });
                 });
             }
 


### PR DESCRIPTION
minmax thresholds try to graph 2 values on a single series which doesnt work in timeseries data. It ends up drawing a z pattern:
![thresholdz](https://cloud.githubusercontent.com/assets/1927558/13022132/f8fb927a-d1a4-11e5-9ac6-d83cebc13148.png)

The fix separates each threshold value into its own series:
![threshold-fixed](https://cloud.githubusercontent.com/assets/1927558/13022139/04367dd0-d1a5-11e5-8652-9fc18fa9fddb.png)

https://jira.zenoss.com/browse/ZEN-21956