### PR TITLE
Java 8 compatibility updates

### DIFF
--- a/central-query-lib/src/main/java/org/zenoss/app/metricservice/api/model/MetricSpecification.java
+++ b/central-query-lib/src/main/java/org/zenoss/app/metricservice/api/model/MetricSpecification.java
@@ -39,7 +39,10 @@ import org.zenoss.app.metricservice.api.impl.Utils;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -328,7 +331,14 @@ public class MetricSpecification {
                 joined.putAll(getTags());
             buf.append('{');
             boolean comma = false;
-            for (Map.Entry<String, List<String>> tag : joined.entrySet()) {
+            List<Map.Entry<String, List<String>>> sortedEntries = new LinkedList<>(joined.entrySet());
+            Collections.sort(sortedEntries, new Comparator<Map.Entry<String, List<String>>>(){
+                @Override
+                public int compare(Map.Entry<String, List<String>>a, Map.Entry<String, List<String>>b) {
+                    return (a.getKey().compareTo(b.getKey()));
+                }});
+
+            for (Map.Entry<String, List<String>> tag : sortedEntries) {
                 if (comma) {
                     buf.append(',');
                 }

--- a/central-query-lib/src/test/java/org/zenoss/app/metricservice/api/model/MetricSpecificationTest.java
+++ b/central-query-lib/src/test/java/org/zenoss/app/metricservice/api/model/MetricSpecificationTest.java
@@ -344,7 +344,7 @@ public class MetricSpecificationTest {
 
     @Test
     public void tagRenderingTest() {
-        String testString = "sum:10s-ago:rate:laLoadInt{tag2=thing|other thing,tag3=bar,tag1=value1|value2|value3}";
+        String testString = "sum:10s-ago:rate:laLoadInt{tag1=value1|value2|value3,tag2=thing|other thing,tag3=bar}";
         MetricSpecification subject = MetricSpecification.fromString(testString);
         String generatedString = subject.toString();
         Assert.assertEquals(testString, generatedString);
@@ -352,7 +352,7 @@ public class MetricSpecificationTest {
 
     @Test
     public void testValidateGoodObjectWithErrorHandling() {
-        String testString = "sum:10s-ago:rate:laLoadInt{tag2=thing|other thing,tag3=bar,tag1=value1|value2|value3}";
+        String testString = "sum:10s-ago:rate:laLoadInt{tag1=value1|value2|value3,tag2=thing|other thing,tag3=bar}";
         MetricSpecification subject = MetricSpecification.fromString(testString);
         List<Object> errorList = new ArrayList<>();
         subject.validateWithErrorHandling(errorList);
@@ -361,7 +361,7 @@ public class MetricSpecificationTest {
 
     @Test
     public void testValidateBadObjectWithErrorHandling() {
-        String testString = "sum:10s-ago:rate:laLoadInt{tag2=thing|other thing,tag3=ba*r,tag1=value1|value2|value3}";
+        String testString = "sum:10s-ago:rate:laLoadInt{tag1=value1|value2|value3,tag2=thing|other thing,tag3=ba*r}";
         MetricSpecification subject = MetricSpecification.fromString(testString);
         List<Object> errorList = new ArrayList<>();
         subject.validateWithErrorHandling(errorList);

--- a/central-query/pom.xml
+++ b/central-query/pom.xml
@@ -17,7 +17,7 @@
         <metric-consumer.version>0.1.0</metric-consumer.version>
         <jersey.version>1.15</jersey.version>
         <junit.version>4.11</junit.version>
-        <spring.version>3.2.1.RELEASE</spring.version>
+        <spring.version>3.2.17.RELEASE</spring.version>
         <dropwizard.version>0.6.2</dropwizard.version>
         <jsdoc3.version>1.0.4</jsdoc3.version>
         <ssl.cert.dir>target/cert</ssl.cert.dir>
@@ -166,7 +166,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.6.3.201306030806</version>
+                <version>0.7.7.201606060606</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Changed some test cases to reflect that toString methods are now ordering tags
by their keys to guarantee order as a compatibility measure.