### PR TITLE
pull in new version of zapp for java 8 compatibility

### DIFF
--- a/central-query/pom.xml
+++ b/central-query/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <zapp.version>0.0.21</zapp.version>
+        <zapp.version>0.0.22</zapp.version>
         <metric-consumer.version>0.1.0</metric-consumer.version>
         <jersey.version>1.15</jersey.version>
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
ZEN-23915: zapp was using an older version of spring, which conflicted with java 8. version 0.0.22 of zapp brings spring up to 3.2.17.RELEASE, which works with java 8. This change updates central query to use the new version of zapp.