### PR TITLE
ZEN-25806 Component graphs exceed graph bounds

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -1624,7 +1624,7 @@
             // extract array of value arrays
             var seriesVals = data.map(function (series) {
                 return series.datapoints.map(function (datapt) { 
-                    return datapt.value === "NaN" ? 0 : datapt.value; });
+                    return datapt.value === "NaN" ? 0 : +datapt.value; });
             });
             // flatten array and calculate max value
             return Math.max.apply(null, [].concat.apply([], seriesVals));

--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -1601,7 +1601,7 @@
             result = data.reduce(function (acc, series) {
                 return Math.min(acc, series.datapoints.reduce(function (acc, dp) {
                     // if the value is the string "NaN", ignore this dp
-                    if (dp.value === "NaN") return acc;
+                    if (dp.value === "NaN" || dp.value === null) return acc;
                     if (nonZero && dp.value === 0) return acc;
                     return Math.min(acc, +dp.value);
                 }, minStartValue));
@@ -1621,18 +1621,13 @@
          * value of all series datapoints in that response
          */
         calculateResultsMax: function (data) {
-
-            var seriesCalc = function (a, b) {
-                return a + b;
-            };
-
-            return data.reduce(function (acc, series) {
-                return seriesCalc(acc, series.datapoints.reduce(function (acc, dp) {
-                    // if the value is the string "NaN", ignore this dp
-                    if (dp.value === "NaN") return acc;
-                    return Math.max(acc, +dp.value);
-                }, 0));
-            }, 0);
+            // extract array of value arrays
+            var seriesVals = data.map(function (series) {
+                return series.datapoints.map(function (datapt) { 
+                    return datapt.value === "NaN" ? 0 : datapt.value; });
+            });
+            // flatten array and calculate max value
+            return Math.max.apply(null, [].concat.apply([], seriesVals));
         },
 
         setPreferredYUnit: function (data) {

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -2869,7 +2869,7 @@ if (typeof exports !== 'undefined') {
             result = data.reduce(function (acc, series) {
                 return Math.min(acc, series.datapoints.reduce(function (acc, dp) {
                     // if the value is the string "NaN", ignore this dp
-                    if (dp.value === "NaN") return acc;
+                    if (dp.value === "NaN" || dp.value === null) return acc;
                     if (nonZero && dp.value === 0) return acc;
                     return Math.min(acc, +dp.value);
                 }, minStartValue));
@@ -2889,18 +2889,13 @@ if (typeof exports !== 'undefined') {
          * value of all series datapoints in that response
          */
         calculateResultsMax: function (data) {
-
-            var seriesCalc = function (a, b) {
-                return a + b;
-            };
-
-            return data.reduce(function (acc, series) {
-                return seriesCalc(acc, series.datapoints.reduce(function (acc, dp) {
-                    // if the value is the string "NaN", ignore this dp
-                    if (dp.value === "NaN") return acc;
-                    return Math.max(acc, +dp.value);
-                }, 0));
-            }, 0);
+            // extract array of value arrays
+            var seriesVals = data.map(function (series) {
+                return series.datapoints.map(function (datapt) { 
+                    return datapt.value === "NaN" ? 0 : +datapt.value; });
+            });
+            // flatten array and calculate max value
+            return Math.max.apply(null, [].concat.apply([], seriesVals));
         },
 
         setPreferredYUnit: function (data) {


### PR DESCRIPTION
Component graphs (most notably when the "All on same graph" checkbox is checked) exceed the chart boundaries, making it difficult if not impossible to interpret the data of the graph.

The root cause of the problem was improper calculation of the chart max value.  By properly calculating the max value of all series for a graph, the proper Y axis is created, permitting all series points to fall within the bounds of the graph.