### PR TITLE
Add projections to lower legend

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -107,6 +107,7 @@
         [31536000000, '10d-avg']  // 1 Year
     ];
 
+    var PROJECTIONCOLORS = ["#EBEBEF", "#FDDFE7", "#FCF1C0", "#DAFBEB"];
 
     Chart = function (name, config) {
         this.name = name;
@@ -624,12 +625,15 @@
             // Add thresholds
             if (this.config.overlays && this.config.overlays.length) {
                 // One row for the stats table header
-                tr = document.createElement('tr');
-                $(tr).addClass("zenfooter_tablerow_header");
-                tr.innerHTML = '<th class="footer_header zenfooter_box_column"></th>' +
-                    '<th class="footer_header zenfooter_data_text" colspan="5">Thresholds</th>';
-                $(this.table).append($(tr));
-                rows.push($(tr));
+                tr = $(this.table).find('tr.zenfooter_tablerow_thresholds');
+                if (tr.length === 0) {
+                    tr = document.createElement('tr');
+                    $(tr).addClass("zenfooter_tablerow_header zenfooter_tablerow_thresholds");
+                    tr.innerHTML = '<th class="footer_header zenfooter_box_column"></th>' +
+                        '<th class="footer_header zenfooter_data_text" colspan="5">Thresholds</th>';
+                    $(this.table).append($(tr));
+                    rows.push($(tr));
+                }
 
                 for (i = 0; i < this.config.overlays.length; i++) {
                     dp = this.config.overlays[i];
@@ -666,6 +670,51 @@
 
                     // Threshold
                     label = dp.legend + '*';
+                    $(cols[1])
+                        .html(label)
+                        .attr('colspan','8') // 5 + 3 projection cells
+                        .addClass('zenfooter_threshold');
+                }
+            }
+
+            // Add Projections.
+            if (this.projections && this.projections.length) {
+                // One row for the stats table header
+                tr = document.createElement('tr');
+                $(tr).addClass("zenfooter_tablerow_header");
+                tr.innerHTML = '<th class="footer_header zenfooter_box_column"></th>' +
+                    '<th class="footer_header zenfooter_data_text" colspan="5">Projections</th>';
+                $(this.table).append($(tr));
+                rows.push($(tr));
+
+                for (i = 0; i < this.projections.length; i++) {
+                    dp = this.projections[i];
+                    row = rows.length;
+
+                    if (row >= rows.length) {
+                        tr = this.__appendFooterRow();
+                        rows.push(tr);
+                        resize = true;
+                        this.__setLegendEvents(tr[0], dp);
+                    }
+
+                    cols = $(rows[row]).find('td');
+
+                    // footer color
+                    color = {
+                        color: PROJECTIONCOLORS[i % PROJECTIONCOLORS.length],
+                        opacity: 1
+                    };
+
+                    // color box
+                    $(cols[0])
+                        .find('div.zenfooter_box')
+                        .css('background-color', color.color)
+                        .css('border-color', color.color)
+                        .css('opacity', color.opacity);
+
+                    // Threshold
+                    label = dp.legend;
                     $(cols[1])
                         .html(label)
                         .attr('colspan','8') // 5 + 3 projection cells
@@ -1031,7 +1080,7 @@
                         }
 
                         // send a separate request for the projection data since it has a different time span
-                        var projectionColors = ["#EBEBEF", "#FDDFE7", "#FCF1C0", "#DAFBEB"], projectionIndex = 0;
+                        var projectionIndex = 0;
                         self.projections.forEach(function (projection) {
                             var projectionRequest = self.__buildProjectionRequest(self.config, self.request, projection);
                             // can fail if the projection is requesting a metric not present
@@ -1055,7 +1104,7 @@
                                         // get the visible x, y values
                                             projectedSet = self.createRegressionData(valueFn, start, end);
                                         self.plots.push({
-                                            color: projectionColors[projectionIndex++ % projectionColors.length],
+                                            color: PROJECTIONCOLORS[projectionIndex++ % PROJECTIONCOLORS.length],
                                             fill: false,
                                             projection: true,
                                             projectionFn: valueFn,

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -1375,6 +1375,7 @@ if (typeof exports !== 'undefined') {
         [31536000000, '10d-avg']  // 1 Year
     ];
 
+    var PROJECTIONCOLORS = ["#EBEBEF", "#FDDFE7", "#FCF1C0", "#DAFBEB"];
 
     Chart = function (name, config) {
         this.name = name;
@@ -1892,12 +1893,15 @@ if (typeof exports !== 'undefined') {
             // Add thresholds
             if (this.config.overlays && this.config.overlays.length) {
                 // One row for the stats table header
-                tr = document.createElement('tr');
-                $(tr).addClass("zenfooter_tablerow_header");
-                tr.innerHTML = '<th class="footer_header zenfooter_box_column"></th>' +
-                    '<th class="footer_header zenfooter_data_text" colspan="5">Thresholds</th>';
-                $(this.table).append($(tr));
-                rows.push($(tr));
+                tr = $(this.table).find('tr.zenfooter_tablerow_thresholds');
+                if (tr.length === 0) {
+                    tr = document.createElement('tr');
+                    $(tr).addClass("zenfooter_tablerow_header zenfooter_tablerow_thresholds");
+                    tr.innerHTML = '<th class="footer_header zenfooter_box_column"></th>' +
+                        '<th class="footer_header zenfooter_data_text" colspan="5">Thresholds</th>';
+                    $(this.table).append($(tr));
+                    rows.push($(tr));
+                }
 
                 for (i = 0; i < this.config.overlays.length; i++) {
                     dp = this.config.overlays[i];
@@ -1934,6 +1938,51 @@ if (typeof exports !== 'undefined') {
 
                     // Threshold
                     label = dp.legend + '*';
+                    $(cols[1])
+                        .html(label)
+                        .attr('colspan','8') // 5 + 3 projection cells
+                        .addClass('zenfooter_threshold');
+                }
+            }
+
+            // Add Projections.
+            if (this.projections && this.projections.length) {
+                // One row for the stats table header
+                tr = document.createElement('tr');
+                $(tr).addClass("zenfooter_tablerow_header");
+                tr.innerHTML = '<th class="footer_header zenfooter_box_column"></th>' +
+                    '<th class="footer_header zenfooter_data_text" colspan="5">Projections</th>';
+                $(this.table).append($(tr));
+                rows.push($(tr));
+
+                for (i = 0; i < this.projections.length; i++) {
+                    dp = this.projections[i];
+                    row = rows.length;
+
+                    if (row >= rows.length) {
+                        tr = this.__appendFooterRow();
+                        rows.push(tr);
+                        resize = true;
+                        this.__setLegendEvents(tr[0], dp);
+                    }
+
+                    cols = $(rows[row]).find('td');
+
+                    // footer color
+                    color = {
+                        color: PROJECTIONCOLORS[i % PROJECTIONCOLORS.length],
+                        opacity: 1
+                    };
+
+                    // color box
+                    $(cols[0])
+                        .find('div.zenfooter_box')
+                        .css('background-color', color.color)
+                        .css('border-color', color.color)
+                        .css('opacity', color.opacity);
+
+                    // Threshold
+                    label = dp.legend;
                     $(cols[1])
                         .html(label)
                         .attr('colspan','8') // 5 + 3 projection cells
@@ -2299,7 +2348,7 @@ if (typeof exports !== 'undefined') {
                         }
 
                         // send a separate request for the projection data since it has a different time span
-                        var projectionColors = ["#EBEBEF", "#FDDFE7", "#FCF1C0", "#DAFBEB"], projectionIndex = 0;
+                        var projectionIndex = 0;
                         self.projections.forEach(function (projection) {
                             var projectionRequest = self.__buildProjectionRequest(self.config, self.request, projection);
                             // can fail if the projection is requesting a metric not present
@@ -2323,7 +2372,7 @@ if (typeof exports !== 'undefined') {
                                         // get the visible x, y values
                                             projectedSet = self.createRegressionData(valueFn, start, end);
                                         self.plots.push({
-                                            color: projectionColors[projectionIndex++ % projectionColors.length],
+                                            color: PROJECTIONCOLORS[projectionIndex++ % PROJECTIONCOLORS.length],
                                             fill: false,
                                             projection: true,
                                             projectionFn: valueFn,


### PR DESCRIPTION
Projections exist in the upper legend, but got missed when we added thresholds to the lower legend and hid the upper legend.  Add them back again.

![chartprojections](https://cloud.githubusercontent.com/assets/15878956/26588605/5f6ab10e-451b-11e7-8ed6-c4cda7ef0e1e.jpg)