### PR TITLE
Feature/zen 28163

### DIFF
--- a/central-query-lib/pom.xml
+++ b/central-query-lib/pom.xml
@@ -66,6 +66,11 @@
             <version>1.0.0.GA</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/central-query-lib/src/main/java/org/zenoss/app/metricservice/api/impl/QueryResult.java
+++ b/central-query-lib/src/main/java/org/zenoss/app/metricservice/api/impl/QueryResult.java
@@ -34,6 +34,8 @@ package org.zenoss.app.metricservice.api.impl;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.util.*;
 
@@ -100,5 +102,33 @@ public class QueryResult {
 
     public Map<String, Collection<String>> getTags() {
         return tags.asMap();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        QueryResult that = (QueryResult) o;
+
+        return new EqualsBuilder()
+                .append(datapoints, that.datapoints)
+                .append(metric, that.metric)
+                .append(tags, that.tags)
+                .append(queryStatus, that.queryStatus)
+                .append(id, that.id)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(datapoints)
+                .append(metric)
+                .append(tags)
+                .append(queryStatus)
+                .append(id)
+                .toHashCode();
     }
 }

--- a/central-query-lib/src/main/java/org/zenoss/app/metricservice/api/impl/QueryResultDataPoint.java
+++ b/central-query-lib/src/main/java/org/zenoss/app/metricservice/api/impl/QueryResultDataPoint.java
@@ -31,6 +31,9 @@
 
 package org.zenoss.app.metricservice.api.impl;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 public class QueryResultDataPoint {
     private long timestamp;
     private double value;
@@ -56,5 +59,27 @@ public class QueryResultDataPoint {
 
     public void setValue(double value) {
         this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        QueryResultDataPoint that = (QueryResultDataPoint) o;
+
+        return new EqualsBuilder()
+                .append(timestamp, that.timestamp)
+                .append(value, that.value)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(timestamp)
+                .append(value)
+                .toHashCode();
     }
 }

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriter.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriter.java
@@ -52,16 +52,6 @@ public class JacksonResultsWriter {
 
     private static final Logger log = LoggerFactory.getLogger(JacksonResultsWriter.class);
 
-    public void writeResults(Writer writer, List<MetricSpecification> queries, Buckets<IHasShortcut> buckets,
-                             String id, String sourceId, long startTs, String startTimeConfig, long endTs,
-                             String endTimeConfig, ReturnSet returnset) throws IOException {
-            SeriesQueryResult results = makeResults(queries, buckets, id, sourceId, startTs, startTimeConfig, endTs, endTimeConfig, returnset);
-            // write results (JSON serialization)
-            String resultJson = Utils.jsonStringFromObject(results);
-            log.debug("Resulting JSON: {}", resultJson);
-            writer.write(resultJson);
-    }
-
     public SeriesQueryResult makeResults(List<MetricSpecification> queries, Buckets<IHasShortcut> buckets,
                                           String id, String sourceId, long startTs, String startTimeConfig, long endTs,
                                           String endTimeConfig, ReturnSet returnset) {

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriter.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriter.java
@@ -62,7 +62,7 @@ public class JacksonResultsWriter {
             writer.write(resultJson);
     }
 
-    private SeriesQueryResult makeResults(List<MetricSpecification> queries, Buckets<IHasShortcut> buckets,
+    public SeriesQueryResult makeResults(List<MetricSpecification> queries, Buckets<IHasShortcut> buckets,
                                           String id, String sourceId, long startTs, String startTimeConfig, long endTs,
                                           String endTimeConfig, ReturnSet returnset) {
         SeriesQueryResult result = new SeriesQueryResult();

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
@@ -450,14 +450,14 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
 
     private static String createModifiedDownsampleRequest(String downsample, double downsampleMultiplier) {
         if (null == downsample || downsample.isEmpty() || downsampleMultiplier <= 0.0) {
-            log.warn("Bad downsample or multiplier. Returning original downsample value of {}.", downsample);
+            log.debug("Bad downsample or multiplier. Returning original downsample value of {}.", downsample);
             return downsample;
         }
         long duration = Utils.parseDuration(downsample);
         String aggregation = parseAggregation(downsample);
         long newDuration = (long) (duration / downsampleMultiplier);
         if (newDuration <= 0) {
-            log.warn("Applying value {} of downsampleMultiplier to downsample value of {} would result in a request with resolution finer than 1 sec. returning 1 second.", downsampleMultiplier, downsample);
+            log.info("Applying value {} of downsampleMultiplier to downsample value of {} would result in a request with resolution finer than 1 sec. returning 1 second.", downsampleMultiplier, downsample);
             newDuration = 1;
         }
         return String.format("%ds-%s", newDuration, aggregation);

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/ResultProcessor.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/ResultProcessor.java
@@ -32,6 +32,7 @@
 package org.zenoss.app.metricservice.api.impl;
 
 import org.zenoss.app.metricservice.buckets.Buckets;
+import org.zenoss.app.metricservice.calculators.BadExpressionException;
 
 import java.io.IOException;
 
@@ -54,5 +55,5 @@ public interface ResultProcessor {
      * @throws ClassNotFoundException
      *             when a calculation engine cannot be loaded
      */
-    public Buckets<IHasShortcut> processResults() throws IOException, ClassNotFoundException;
+    public Buckets<IHasShortcut> processResults() throws IOException, ClassNotFoundException, BadExpressionException;
 }

--- a/central-query/src/main/java/org/zenoss/app/metricservice/calculators/BadExpressionException.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/calculators/BadExpressionException.java
@@ -1,0 +1,14 @@
+/*
+* © Zenoss, Inc. 2017, all rights reserved.
+*  Use is subject to terms as shown in the License.zenoss file.
+*/
+
+package org.zenoss.app.metricservice.calculators;
+
+public class BadExpressionException extends Exception {
+    private static final long serialVersionUID = 3505599798296249875L;
+
+    public BadExpressionException(String expression, Exception e) {
+        super(String.format("Unable to apply expression %s", expression), e);
+    }
+}

--- a/central-query/src/main/java/org/zenoss/app/metricservice/calculators/MetricCalculator.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/calculators/MetricCalculator.java
@@ -68,10 +68,10 @@ public interface MetricCalculator {
      * @return result of the expression evaluation
      */
     double evaluate(double value, String expression, Closure closure)
-            throws UnknownReferenceException;
+            throws UnknownReferenceException, BadExpressionException;
 
     double evaluate(double value, String expression)
-            throws UnknownReferenceException;
+            throws UnknownReferenceException, BadExpressionException;
 
     /**
      * Evaluate the given expression.
@@ -81,9 +81,9 @@ public interface MetricCalculator {
      * @return result of the expression evaluation
      */
     public double evaluate(String expression, Closure closure)
-            throws UnknownReferenceException;
+            throws UnknownReferenceException, BadExpressionException;
 
-    public double evaluate(String expression) throws UnknownReferenceException;
+    public double evaluate(String expression) throws UnknownReferenceException, BadExpressionException;
 
     /**
      * Evaluate the saved expression using the given value as an initial value
@@ -97,11 +97,11 @@ public interface MetricCalculator {
      * @return result of the saved expression evaluation
      */
     public double evaluate(double value, Closure closure)
-            throws UnknownReferenceException;
+            throws UnknownReferenceException, BadExpressionException;
 
-    public double evaluate(double value) throws UnknownReferenceException;
+    public double evaluate(double value) throws UnknownReferenceException, BadExpressionException;
 
-    public double evaluate(Closure closure) throws UnknownReferenceException;
+    public double evaluate(Closure closure) throws UnknownReferenceException, BadExpressionException;
 
-    public double evaluate() throws UnknownReferenceException;
+    public double evaluate() throws UnknownReferenceException, BadExpressionException;
 }

--- a/central-query/src/main/java/org/zenoss/app/metricservice/calculators/rpn/RPNException.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/calculators/rpn/RPNException.java
@@ -1,0 +1,16 @@
+/*
+* © Zenoss, Inc. 2017, all rights reserved.
+*  Use is subject to terms as shown in the License.zenoss file.
+*/
+
+package org.zenoss.app.metricservice.calculators.rpn;
+
+import org.zenoss.app.metricservice.calculators.BadExpressionException;
+
+public class RPNException extends BadExpressionException {
+    private static final long serialVersionUID = -478064808047872067L;
+
+    public RPNException(String expression, Exception e) {
+        super(expression, e);
+    }
+}

--- a/central-query/src/main/java/org/zenoss/app/metricservice/v2/impl/QueryServiceImpl.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/v2/impl/QueryServiceImpl.java
@@ -11,6 +11,8 @@
 
 package org.zenoss.app.metricservice.v2.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
@@ -29,11 +31,7 @@ import org.zenoss.app.metricservice.api.model.ReturnSet;
 import org.zenoss.app.metricservice.api.model.v2.*;
 import org.zenoss.app.metricservice.api.model.v2.QueryResult;
 import org.zenoss.app.metricservice.buckets.Value;
-import org.zenoss.app.metricservice.calculators.Closure;
-import org.zenoss.app.metricservice.calculators.MetricCalculator;
-import org.zenoss.app.metricservice.calculators.MetricCalculatorFactory;
-import org.zenoss.app.metricservice.calculators.ReferenceProvider;
-import org.zenoss.app.metricservice.calculators.UnknownReferenceException;
+import org.zenoss.app.metricservice.calculators.*;
 import org.zenoss.app.metricservice.v2.QueryService;
 
 import javax.annotation.Nullable;
@@ -110,7 +108,7 @@ public class QueryServiceImpl implements QueryService {
                         qrb.addSeries(m.metric, m.getDataPoints(), m.tags);
                     }
                     qrb.setStatus(otsdbResults.getStatus());
-                } catch (UnknownReferenceException e) {
+                } catch (UnknownReferenceException | BadExpressionException e) {
                     QueryStatus status = new QueryStatus();
                     status.setMessage(e.getMessage());
                     status.setStatus(QueryStatusEnum.ERROR);
@@ -163,7 +161,7 @@ public class QueryServiceImpl implements QueryService {
         return results;
     }
 
-    private void applyRPN(Entry<String, Collection<MetricQuery>> specs, Iterable<OpenTSDBQueryResult> result) throws UnknownReferenceException {
+    private void applyRPN(Entry<String, Collection<MetricQuery>> specs, Iterable<OpenTSDBQueryResult> result) throws UnknownReferenceException, BadExpressionException {
         for (final OpenTSDBQueryResult r : result) {
             MetricCalculator calc;
             try {

--- a/central-query/src/test/java/org/zenoss/app/metricservice/RpnTest.java
+++ b/central-query/src/test/java/org/zenoss/app/metricservice/RpnTest.java
@@ -54,7 +54,7 @@ public class RpnTest {
 
     @Test
     public void basicAddition() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("5,1,10,+,+");
@@ -63,7 +63,7 @@ public class RpnTest {
 
     @Test
     public void basicSubtraction() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("5,1,10,-,-");
@@ -72,7 +72,7 @@ public class RpnTest {
 
     @Test
     public void basicMultiplication() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("5,1,10,*,*");
@@ -81,7 +81,7 @@ public class RpnTest {
 
     @Test
     public void basicDivision() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("5,1,10,/,/");
@@ -89,7 +89,7 @@ public class RpnTest {
     }
 
     @Test
-    public void min() throws ClassNotFoundException, UnknownReferenceException {
+    public void min() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("5, 10, min");
@@ -97,7 +97,7 @@ public class RpnTest {
     }
 
     @Test
-    public void max() throws ClassNotFoundException, UnknownReferenceException {
+    public void max() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("5, 10, max");
@@ -105,7 +105,7 @@ public class RpnTest {
     }
 
     @Test
-    public void dup() throws ClassNotFoundException, UnknownReferenceException {
+    public void dup() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("5, dup, +");
@@ -114,7 +114,7 @@ public class RpnTest {
 
     @Test
     public void example1() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("128,8,*");
@@ -123,7 +123,7 @@ public class RpnTest {
 
     @Test
     public void example2() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("1024,7000,gt");
@@ -132,7 +132,7 @@ public class RpnTest {
 
     @Test
     public void example3() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
 
@@ -148,7 +148,7 @@ public class RpnTest {
 
     @Test
     public void example4() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("128,8,*,7000,GT,7000,128,8,*,IF");
@@ -156,7 +156,7 @@ public class RpnTest {
     }
 
     @Test
-    public void mod() throws ClassNotFoundException, UnknownReferenceException {
+    public void mod() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         double result = calc.evaluate("1234,100,%");
@@ -164,7 +164,7 @@ public class RpnTest {
     }
 
     @Test
-    public void sort() throws ClassNotFoundException, UnknownReferenceException {
+    public void sort() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         String in = "9, 3, 4, 5, 1, 2, 8, 6, 7, 0, 10, sort";
@@ -179,7 +179,7 @@ public class RpnTest {
     }
 
     @Test
-    public void rev() throws ClassNotFoundException, UnknownReferenceException {
+    public void rev() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         String in = "9, 3, 4, 5, 1, 2, 8, 6, 7, 0, 10, rev";
@@ -225,7 +225,7 @@ public class RpnTest {
 
     @Test
     public void NanAndInfinityTest() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         Assert.assertEquals("Positive infinity", 1.0,
@@ -244,7 +244,7 @@ public class RpnTest {
 
     @Test
     public void TimeTest() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         Assert.assertEquals("Now", new Date().getTime() / 1000,
@@ -253,7 +253,7 @@ public class RpnTest {
 
     @Test
     public void LimitTest() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         Assert.assertEquals("In Limit", 5.0, calc.evaluate("5, 0, 10, limit"),
@@ -266,7 +266,7 @@ public class RpnTest {
 
     @Test
     public void AddNanTest() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         Assert.assertEquals("Left side unknown", 5.0,
@@ -280,7 +280,7 @@ public class RpnTest {
 
     @Test
     public void exchangeTest() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         Assert.assertEquals(1.0, calc.evaluate("1,2,exc"), 0.0);
@@ -292,7 +292,7 @@ public class RpnTest {
 
     @Test
     public void regression1() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         Assert.assertEquals(
@@ -310,7 +310,7 @@ public class RpnTest {
 
     @Test
     public void referenceTest() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
@@ -332,7 +332,7 @@ public class RpnTest {
 
     @Test
     public void unknownReferenceTest() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
@@ -357,7 +357,7 @@ public class RpnTest {
 
     @Test
     public void referenceTestWithClosure() throws ClassNotFoundException,
-            UnknownReferenceException {
+            UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory()
                 .newInstance("rpn");
         final Closure data = mock(Closure.class);
@@ -382,7 +382,7 @@ public class RpnTest {
     }
 
     @Test
-    public void referenceBeginningWithHyphenShouldWork() throws ClassNotFoundException, UnknownReferenceException {
+    public void referenceBeginningWithHyphenShouldWork() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory().newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
 
@@ -402,7 +402,7 @@ public class RpnTest {
     }
 
     @Test
-    public void referencesBeginningWithPlusShouldWork() throws ClassNotFoundException, UnknownReferenceException {
+    public void referencesBeginningWithPlusShouldWork() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory().newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
 
@@ -419,7 +419,7 @@ public class RpnTest {
         Assert.assertEquals("A reference beginning with '+' should work.",6.0, calc.evaluate("+ this is a test,3.0,*"), 0.0);
     }
     @Test
-    public void numbersBeginningWithPlusShouldWork() throws ClassNotFoundException, UnknownReferenceException {
+    public void numbersBeginningWithPlusShouldWork() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory().newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
 
@@ -437,7 +437,7 @@ public class RpnTest {
     }
 
     @Test
-    public void referenceBeginningWithSlashShouldWork() throws ClassNotFoundException, UnknownReferenceException {
+    public void referenceBeginningWithSlashShouldWork() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory().newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
 
@@ -457,7 +457,7 @@ public class RpnTest {
     }
 
     @Test
-    public void referenceBeginningWithAsteriskShouldWork() throws ClassNotFoundException, UnknownReferenceException {
+    public void referenceBeginningWithAsteriskShouldWork() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory().newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
 
@@ -477,7 +477,7 @@ public class RpnTest {
     }
 
     @Test
-    public void referenceBeginningWithPercentShouldWork() throws ClassNotFoundException, UnknownReferenceException {
+    public void referenceBeginningWithPercentShouldWork() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory().newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
 
@@ -496,7 +496,7 @@ public class RpnTest {
         Assert.assertEquals("A reference beginning with '%' should work",6.0, calc.evaluate("% this is a test,ref2,*"), 0.0);
     }
     @Test
-    public void referenceBeginningWithDigitShouldWork() throws ClassNotFoundException, UnknownReferenceException {
+    public void referenceBeginningWithDigitShouldWork() throws ClassNotFoundException, UnknownReferenceException, BadExpressionException {
         MetricCalculator calc = new MetricCalculatorFactory().newInstance("rpn");
         calc.setReferenceProvider(new ReferenceProvider() {
 

--- a/central-query/src/test/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriterTest.java
+++ b/central-query/src/test/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriterTest.java
@@ -32,6 +32,7 @@
 package org.zenoss.app.metricservice.api.impl;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.zenoss.app.metricservice.api.model.MetricSpecification;
@@ -41,24 +42,26 @@ import org.zenoss.app.metricservice.buckets.Buckets;
 import org.zenoss.app.metricservice.testutil.ConstantSeriesGenerator;
 import org.zenoss.app.metricservice.testutil.SeriesGenerator;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 
 public class JacksonResultsWriterTest {
     private static final String TESTID = "TEST_ID";
+    private static final String TEST_SOURCE_ID = "test_source_id";
     private static final long DATA_START_TIMESTAMP = 1078033800;
     private static final long DATA_END_TIMESTAMP = 1078034400;
     private static final long DATA_TIMESTAMP_STEP = 600;
 
     @Test
-    public void testMakeResults() {
+    public void testMakeResults() throws IOException {
         JacksonResultsWriter victim = new JacksonResultsWriter();
         String[] queryStrings = new String[] {
                 "avg:laLoadInt1{tag1=*,tag2=*}",
                 "sum:laLoadInt5{tag1=*,tag2=*}" };
-        SeriesQueryResult sqrExpected = new SeriesQueryResult();
 
         List<MetricSpecification> queries = makeTestQueries(queryStrings);
         long startTs = DATA_START_TIMESTAMP;
@@ -67,13 +70,35 @@ public class JacksonResultsWriterTest {
         Buckets<IHasShortcut> buckets = makeTestBuckets(queries, new ConstantSeriesGenerator(10.0), startTs, endTs, step);
         BucketTestUtilities.dumpBucketsToStdout(buckets);
         String id = TESTID;
-        String sourceId = "test_source_id";
+        String sourceId = TEST_SOURCE_ID;
         String startTimeConfig = Long.toString(startTs);
         String endTimeConfig = Long.toString(endTs);
         ReturnSet returnset = ReturnSet.ALL;
+
+        Collection<QueryResult> expectedResults = new ArrayList<>();
+
+        String qr1str = "{\"metric\":\"laLoadInt1\",\"tags\":{\"tag1\":[\"*\"],\"tag2\":[\"*\"]},\"datapoints\":[{\"timestamp\":1078033800, \"value\":10.0},{\"timestamp\":1078034400, \"value\":10.0}]}";
+        String qr2str = "{\"metric\":\"laLoadInt5\",\"tags\":{\"tag1\":[\"*\"],\"tag2\":[\"*\"]},\"datapoints\":[{\"timestamp\":1078033800, \"value\":10.0},{\"timestamp\":1078034400, \"value\":10.0}]}";
+        ObjectMapper mapper = new ObjectMapper();
+        QueryResult qr1 = mapper.readValue(qr1str, QueryResult.class);
+        QueryResult qr2 = mapper.readValue(qr2str, QueryResult.class);
+        expectedResults.add(qr1);
+        expectedResults.add(qr2);
+
         final SeriesQueryResult seriesQueryResult = victim.makeResults(queries, buckets, id, sourceId, startTs, startTimeConfig, endTs, endTimeConfig, returnset);
+
         Assert.assertNotNull(seriesQueryResult);
-        Assert.assertTrue("Unexpected result", sqrExpected.equals(seriesQueryResult));
+        Assert.assertEquals("client ID mismatch in query result", id, seriesQueryResult.getClientId());
+        Assert.assertEquals("endTime mismatch in query result", endTimeConfig, seriesQueryResult.getEndTime());
+        Assert.assertEquals("endTimeActual mismatch in query result", endTs, seriesQueryResult.getEndTimeActual());
+        Assert.assertEquals("returnset mismatch in query result", returnset, seriesQueryResult.getReturnset());
+        Assert.assertEquals("series mismatch in query result", true, seriesQueryResult.isSeries());
+        Assert.assertEquals("source mismatch in query result", sourceId, seriesQueryResult.getSource());
+        Assert.assertEquals("startTime mismatch in query result", startTimeConfig, seriesQueryResult.getStartTime());
+        Assert.assertEquals("startTimeActual mismatch in query result", startTs, seriesQueryResult.getStartTimeActual());
+        Collection<QueryResult> ar = seriesQueryResult.getResults();
+        Assert.assertEquals("result sizes mismatch in query results", expectedResults.size(), ar.size());
+        Assert.assertEquals("results mismatch in query results", expectedResults, ar);
     }
 
     private Buckets<IHasShortcut> makeTestBuckets(List<MetricSpecification> queries, SeriesGenerator generator, long startTimestamp, long endTimestamp, long step) {

--- a/central-query/src/test/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriterTest.java
+++ b/central-query/src/test/java/org/zenoss/app/metricservice/api/impl/JacksonResultsWriterTest.java
@@ -31,6 +31,8 @@
 
 package org.zenoss.app.metricservice.api.impl;
 
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.zenoss.app.metricservice.api.model.MetricSpecification;
 import org.zenoss.app.metricservice.api.model.ReturnSet;
@@ -39,7 +41,6 @@ import org.zenoss.app.metricservice.buckets.Buckets;
 import org.zenoss.app.metricservice.testutil.ConstantSeriesGenerator;
 import org.zenoss.app.metricservice.testutil.SeriesGenerator;
 
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -52,11 +53,12 @@ public class JacksonResultsWriterTest {
     private static final long DATA_TIMESTAMP_STEP = 600;
 
     @Test
-    public void testWriteResults() throws Exception {
+    public void testMakeResults() {
         JacksonResultsWriter victim = new JacksonResultsWriter();
         String[] queryStrings = new String[] {
-            "avg:laLoadInt1{tag1=*,tag2=*}",
-            "sum:laLoadInt5{tag1=*,tag2=*}" };
+                "avg:laLoadInt1{tag1=*,tag2=*}",
+                "sum:laLoadInt5{tag1=*,tag2=*}" };
+        SeriesQueryResult sqrExpected = new SeriesQueryResult();
 
         List<MetricSpecification> queries = makeTestQueries(queryStrings);
         long startTs = DATA_START_TIMESTAMP;
@@ -69,10 +71,9 @@ public class JacksonResultsWriterTest {
         String startTimeConfig = Long.toString(startTs);
         String endTimeConfig = Long.toString(endTs);
         ReturnSet returnset = ReturnSet.ALL;
-        StringWriter writer = new StringWriter();
-        victim.writeResults(writer, queries, buckets, id, sourceId, startTs, startTimeConfig, endTs, endTimeConfig, returnset);
-        say("RESULTS:");
-        say(writer.toString());
+        final SeriesQueryResult seriesQueryResult = victim.makeResults(queries, buckets, id, sourceId, startTs, startTimeConfig, endTs, endTimeConfig, returnset);
+        Assert.assertNotNull(seriesQueryResult);
+        Assert.assertTrue("Unexpected result", sqrExpected.equals(seriesQueryResult));
     }
 
     private Buckets<IHasShortcut> makeTestBuckets(List<MetricSpecification> queries, SeriesGenerator generator, long startTimestamp, long endTimestamp, long step) {


### PR DESCRIPTION
ZEN-28163: fix v2 query service to capture and report bad RPN expression, rather than blowing up.
ZEN-26776: same fix for v1 query service.
Refactored (with help from @jplouis) v1 code as part of ZEN-26776 fix - got rid of stream-based code (which wasn't really working as stream-based).
Also, fixed annoying log messages in OpenTSDBMetricStorage.java - bumped levels down to make them more appropriate to the conditions.