### PR TITLE
ZEN-21471 apply dp formats in footer

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -219,7 +219,7 @@
          *            If toEng function should ignore the preferred unit
          *            and calculate a unit based on `value`
          */
-        formatValue: function (value, ignorePreferred, skipCalc) {
+        formatValue: function (value, ignorePreferred, dpFormat, skipCalc) {
             /*
              * If we were given a undefined value, Infinity, of NaN (all things that
              * can't be formatted, then just return the value.
@@ -227,8 +227,11 @@
             if (!$.isNumeric(value)) {
                 return value;
             }
+            if (dpFormat === undefined) {
+                dpFormat = this.format;
+            }
 
-            return toEng(value, ignorePreferred ? undefined : this.preferredYUnit, this.format, this.base, skipCalc);
+            return toEng(value, ignorePreferred ? undefined : this.preferredYUnit, dpFormat, this.base, skipCalc);
         },
 
         /**
@@ -608,7 +611,7 @@
                             }
 
                             for (v = 0; v < vals.length; v += 1) {
-                                $(cols[2 + v]).html(this.formatValue(vals[v], undefined, dp.displayFullValue));
+                                $(cols[2 + v]).html(this.formatValue(vals[v], undefined, dp.format, dp.displayFullValue));
                             }
                         }
                         row += 1;

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -1487,7 +1487,7 @@ if (typeof exports !== 'undefined') {
          *            If toEng function should ignore the preferred unit
          *            and calculate a unit based on `value`
          */
-        formatValue: function (value, ignorePreferred, skipCalc) {
+        formatValue: function (value, ignorePreferred, dpFormat, skipCalc) {
             /*
              * If we were given a undefined value, Infinity, of NaN (all things that
              * can't be formatted, then just return the value.
@@ -1495,8 +1495,11 @@ if (typeof exports !== 'undefined') {
             if (!$.isNumeric(value)) {
                 return value;
             }
+            if (dpFormat === undefined) {
+                dpFormat = this.format;
+            }
 
-            return toEng(value, ignorePreferred ? undefined : this.preferredYUnit, this.format, this.base, skipCalc);
+            return toEng(value, ignorePreferred ? undefined : this.preferredYUnit, dpFormat, this.base, skipCalc);
         },
 
         /**
@@ -1876,7 +1879,7 @@ if (typeof exports !== 'undefined') {
                             }
 
                             for (v = 0; v < vals.length; v += 1) {
-                                $(cols[2 + v]).html(this.formatValue(vals[v], undefined, dp.displayFullValue));
+                                $(cols[2 + v]).html(this.formatValue(vals[v], undefined, dp.format, dp.displayFullValue));
                             }
                         }
                         row += 1;


### PR DESCRIPTION
fix applys datapoints formats in graph footer
Values in pop up window still reffers to datapoints[0].format so they still have the same format
[Jira & demo](https://jira.zenoss.com/browse/ZEN-21471)