### PR TITLE
ZEN-28753: Drop OpenTSDB writer cache after reidentifying a device

### DIFF
--- a/central-query/src/main/etc/configuration.yaml
+++ b/central-query/src/main/etc/configuration.yaml
@@ -8,7 +8,8 @@ metrics:
   defaultStartTime: 1h-ago
   defaultEndTime: now
   defaultSeries: true
-  openTsdbUrl: http://127.0.0.1:4242
+  openTsdbReaderUrl: http://127.0.0.1:4242
+  openTsdbWriterUrl: http://127.0.0.1:4243
   defaultTsdTimeZone: UTC
   connectionTimeoutMs: 20000
   sendRateOptions: false

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/configs/MetricServiceConfig.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/configs/MetricServiceConfig.java
@@ -50,7 +50,10 @@ public class MetricServiceConfig {
     private Boolean defaultSeries = Boolean.FALSE;
 
     @JsonProperty
-    private String openTsdbUrl = "http://localhost:4242";
+    private String openTsdbReaderUrl = "http://localhost:4242";
+
+    @JsonProperty
+    private String openTsdbWriterUrl = "http://localhost:4243";
 
     @JsonProperty
     private String defaultTsdTimeZone = "UTC";
@@ -144,10 +147,17 @@ public class MetricServiceConfig {
     }
 
     /**
-     * @return the openTsdbUrl
+     * @return the openTsdbReaderUrl
      */
-    public final String getOpenTsdbUrl() {
-        return openTsdbUrl;
+    public final String getOpenTsdbReaderUrl() {
+        return openTsdbReaderUrl;
+    }
+
+    /**
+     * @return the openTsdbWriterUrl
+     */
+    public final String getOpenTsdbWriterUrl() {
+        return openTsdbWriterUrl;
     }
 
     /**
@@ -186,19 +196,37 @@ public class MetricServiceConfig {
     }
 
     /**
-     * @param openTsdbUrl the openTsdbUrl to set
+     * @param openTsdbReaderUrl the openTsdbReaderUrl to set
      */
-    public final void setOpenTsdbUrl(String openTsdbUrl) {
+
+    public final void setOpenTsdbReaderUrl(String openTsdbReaderUrl) {
 
         /**
          * If the given value ends with a '/', then lets trim it as we will add
          * that later on.
          */
-        if (openTsdbUrl.endsWith("/")) {
-            this.openTsdbUrl = openTsdbUrl.substring(0,
-                    openTsdbUrl.length() - 1);
+        if (openTsdbReaderUrl.endsWith("/")) {
+            this.openTsdbReaderUrl = openTsdbReaderUrl.substring(0,
+                    openTsdbReaderUrl.length() - 1);
         } else {
-            this.openTsdbUrl = openTsdbUrl;
+            this.openTsdbReaderUrl = openTsdbReaderUrl;
+        }
+    }
+
+    /**
+     * @param openTsdbWriterUrl the openTsdbWriterUrl to set
+     */
+    public final void setOpenTsdbWriterUrl(String openTsdbWriterUrl) {
+
+        /**
+         * If the given value ends with a '/', then lets trim it as we will add
+         * that later on.
+         */
+        if (openTsdbWriterUrl.endsWith("/")) {
+            this.openTsdbWriterUrl = openTsdbWriterUrl.substring(0,
+                    openTsdbWriterUrl.length() - 1);
+        } else {
+            this.openTsdbWriterUrl = openTsdbWriterUrl;
         }
     }
 

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
@@ -95,8 +95,10 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiRenameUrl());
         OpenTSDBClient suggestClient =
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiSuggestUrl());
-        OpenTSDBClient dropCacheClient =
-            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropCacheUrl());
+        OpenTSDBClient dropReaderCacheClient =
+            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropReaderCacheUrl());
+        OpenTSDBClient dropWriterCacheClient =
+            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropWriterCacheUrl());
 
         final String oldPrefix = renameRequest.getOldName();
         final String newPrefix = renameRequest.getNewName();
@@ -211,7 +213,8 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         // in order to hit all of them, although it does not gurantee that all of
         // them will be hit.
         for (int i = 0; i < config.getMetricServiceConfig().getDropCacheTries(); i++) {
-            dropCacheClient.dropCache(getOpenTSDBApiDropCacheUrl());
+            dropReaderCacheClient.dropCache(getOpenTSDBApiDropReaderCacheUrl());
+            dropWriterCacheClient.dropCache(getOpenTSDBApiDropWriterCacheUrl());
         }
     }
 
@@ -219,8 +222,10 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
     public void renameWhole(RenameRequest renameRequest, Writer writer) {
         OpenTSDBClient renameClient =
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiRenameUrl());
-        OpenTSDBClient dropCacheClient =
-            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropCacheUrl());
+        OpenTSDBClient dropReaderCacheClient =
+            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropReaderCacheUrl());
+        OpenTSDBClient dropWriterCacheClient =
+            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropWriterCacheUrl());
 
         final String type = renameRequest.getType();
         final String oldName = renameRequest.getOldName();
@@ -279,7 +284,8 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         }
 
         for (int i = 0; i < config.getMetricServiceConfig().getDropCacheTries(); i++) {
-            dropCacheClient.dropCache(getOpenTSDBApiDropCacheUrl());
+            dropReaderCacheClient.dropCache(getOpenTSDBApiDropReaderCacheUrl());
+            dropWriterCacheClient.dropCache(getOpenTSDBApiDropWriterCacheUrl());
         }
     }
 
@@ -370,16 +376,19 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
 
 
     private String getOpenTSDBApiQueryUrl() {
-        return String.format("%s/api/query", config.getMetricServiceConfig().getOpenTsdbUrl());
+        return String.format("%s/api/query", config.getMetricServiceConfig().getOpenTsdbReaderUrl());
     }
     private String getOpenTSDBApiSuggestUrl(){
-        return String.format("%s/api/suggest", config.getMetricServiceConfig().getOpenTsdbUrl());
+        return String.format("%s/api/suggest", config.getMetricServiceConfig().getOpenTsdbReaderUrl());
     }
     private String getOpenTSDBApiRenameUrl() {
-        return String.format("%s/api/uid/rename", config.getMetricServiceConfig().getOpenTsdbUrl());
+        return String.format("%s/api/uid/rename", config.getMetricServiceConfig().getOpenTsdbReaderUrl());
     }
-    private String getOpenTSDBApiDropCacheUrl(){
-        return String.format("%s/api/dropcaches", config.getMetricServiceConfig().getOpenTsdbUrl());
+    private String getOpenTSDBApiDropReaderCacheUrl(){
+        return String.format("%s/api/dropcaches", config.getMetricServiceConfig().getOpenTsdbReaderUrl());
+    }
+    private String getOpenTSDBApiDropWriterCacheUrl(){
+        return String.format("%s/api/dropcaches", config.getMetricServiceConfig().getOpenTsdbWriterUrl());
     }
 
     private static OpenTSDBSubQuery createOTSDBQuery(MetricQuery mq) {

--- a/central-query/src/main/java/org/zenoss/app/metricservice/health/OpenTsdbReaderHealthCheck.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/health/OpenTsdbReaderHealthCheck.java
@@ -47,14 +47,14 @@ import java.util.Map;
 
 @Configuration
 @HealthCheck
-public class OpenTsdbHealthCheck extends com.yammer.metrics.core.HealthCheck {
+public class OpenTsdbReaderHealthCheck extends com.yammer.metrics.core.HealthCheck {
     @Autowired
     MetricServiceAppConfiguration config;
 
     private static DefaultHttpClient httpclient = new DefaultHttpClient();
 
-    protected OpenTsdbHealthCheck() {
-        super("OpenTSDB");
+    protected OpenTsdbReaderHealthCheck() {
+        super("OpenTSDB Reader");
     }
 
     @Override
@@ -66,7 +66,7 @@ public class OpenTsdbHealthCheck extends com.yammer.metrics.core.HealthCheck {
 
         try {
 
-            HttpGet httpget = new HttpGet(config.getMetricServiceConfig().getOpenTsdbUrl() + "/api/stats");
+            HttpGet httpget = new HttpGet(config.getMetricServiceConfig().getOpenTsdbReaderUrl() + "/api/stats");
             HttpResponse response = httpclient.execute(httpget);
 
             entity = response.getEntity();
@@ -74,7 +74,7 @@ public class OpenTsdbHealthCheck extends com.yammer.metrics.core.HealthCheck {
 
             int code = response.getStatusLine().getStatusCode();
             if (code != Response.Status.OK.getStatusCode()) {
-                return Result.unhealthy("Unexpected result code from OpenTSDB Server: " + code);
+                return Result.unhealthy("Unexpected result code from OpenTSDB Reader Server: " + code);
             }
 
             // Exception if unable to parse object from input stream.

--- a/central-query/src/main/java/org/zenoss/app/metricservice/health/OpenTsdbWriterHealthCheck.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/health/OpenTsdbWriterHealthCheck.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2013, Zenoss and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Zenoss or the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.zenoss.app.metricservice.health;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.zenoss.app.metricservice.MetricServiceAppConfiguration;
+import org.zenoss.dropwizardspring.annotations.HealthCheck;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.HttpEntity;
+import org.apache.http.util.EntityUtils;
+
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+import java.util.Map;
+
+@Configuration
+@HealthCheck
+public class OpenTsdbWriterHealthCheck extends com.yammer.metrics.core.HealthCheck {
+    @Autowired
+    MetricServiceAppConfiguration config;
+
+    private static DefaultHttpClient httpclient = new DefaultHttpClient();
+
+    protected OpenTsdbWriterHealthCheck() {
+        super("OpenTSDB Writer");
+    }
+
+    @Override
+    protected Result check() throws Exception {
+
+        HttpGet httpGet = null;
+        InputStream instream = null;
+        HttpEntity entity = null;
+
+        try {
+
+            HttpGet httpget = new HttpGet(config.getMetricServiceConfig().getOpenTsdbWriterUrl() + "/api/stats");
+            HttpResponse response = httpclient.execute(httpget);
+
+            entity = response.getEntity();
+            instream = entity.getContent();
+
+            int code = response.getStatusLine().getStatusCode();
+            if (code != Response.Status.OK.getStatusCode()) {
+                return Result.unhealthy("Unexpected result code from OpenTSDB Writer Server: " + code);
+            }
+
+            // Exception if unable to parse object from input stream.
+            new ObjectMapper().reader(Map[].class).readValue(instream).toString();
+
+            return Result.healthy();
+
+        } catch (Exception e) {
+
+            return Result.unhealthy(e);
+
+        } finally {
+
+            if (instream != null) {
+                instream.close();
+            }
+
+            if (entity != null) {
+                EntityUtils.consume(entity);
+            }
+
+        }
+    }
+}

--- a/central-query/src/test/java/org/zenoss/app/metricservice/MetricServiceConfigTest.java
+++ b/central-query/src/test/java/org/zenoss/app/metricservice/MetricServiceConfigTest.java
@@ -46,7 +46,8 @@ public class MetricServiceConfigTest {
     private static final ReturnSet RETURN_SET = ReturnSet.EXACT;
     private static final boolean SERIES = false;
     private static final String TSDB_TZ = "UTC";
-    private static final String TSDB_URL = "http://localhost:4242";
+    private static final String TSDB_READER_URL = "http://localhost:4242";
+    private static final String TSDB_WRITER_URL = "http://localhost:4243";
     private static final int CONN_TIMEOUT_MS = 1000;
     private static final int EXEC_THREAD_POOL_MAX_SIZE = 37;
     private static final int EXEC_THREAD_POOL_CORE_SIZE = 17;
@@ -62,7 +63,8 @@ public class MetricServiceConfigTest {
         config.setDefaultReturnSet(RETURN_SET);
         config.setDefaultSeries(SERIES);
         config.setDefaultTsdTimeZone(TSDB_TZ);
-        config.setOpenTsdbUrl(TSDB_URL);
+        config.setOpenTsdbReaderUrl(TSDB_READER_URL);
+        config.setOpenTsdbWriterUrl(TSDB_WRITER_URL);
         config.setConnectionTimeoutMs(CONN_TIMEOUT_MS);
         config.setExecutorThreadPoolMaxSize(EXEC_THREAD_POOL_MAX_SIZE);
         config.setExecutorThreadPoolCoreSize(EXEC_THREAD_POOL_CORE_SIZE);
@@ -75,7 +77,8 @@ public class MetricServiceConfigTest {
         Assert.assertEquals(RETURN_SET, config.getDefaultReturnSet());
         Assert.assertEquals(SERIES, config.getDefaultSeries());
         Assert.assertEquals(TSDB_TZ, config.getDefaultTsdTimeZone());
-        Assert.assertEquals(TSDB_URL, config.getOpenTsdbUrl());
+        Assert.assertEquals(TSDB_READER_URL, config.getOpenTsdbReaderUrl());
+        Assert.assertEquals(TSDB_WRITER_URL, config.getOpenTsdbWriterUrl());
         Assert.assertEquals(CONN_TIMEOUT_MS, config.getConnectionTimeoutMs());
         Assert.assertEquals(EXEC_THREAD_POOL_MAX_SIZE, config.getExecutorThreadPoolMaxSize());
         Assert.assertEquals(EXEC_THREAD_POOL_CORE_SIZE, config.getExecutorThreadPoolCoreSize());
@@ -87,7 +90,9 @@ public class MetricServiceConfigTest {
     @Test
     public void testPerformanceMetricQueryConfigStripsTrailingSlashFromURL() {
         MetricServiceConfig config = new MetricServiceConfig();
-        config.setOpenTsdbUrl(TSDB_URL + '/');
-        Assert.assertEquals(TSDB_URL, config.getOpenTsdbUrl());
+        config.setOpenTsdbReaderUrl(TSDB_READER_URL + '/');
+        config.setOpenTsdbWriterUrl(TSDB_WRITER_URL + '/');
+        Assert.assertEquals(TSDB_READER_URL, config.getOpenTsdbReaderUrl());
+        Assert.assertEquals(TSDB_WRITER_URL, config.getOpenTsdbWriterUrl());
     }
 }


### PR DESCRIPTION
Added writer url http://127.0.0.1:4243 in the config.
Replaced all "openTsdb" in variable names to "openTsdbReader" to differentiate reader from writer.
Added lines for dropping cache on writer.
In the accompanying change in service definition for centralquery, an endpoint for writer will be added.