### PR TITLE
If no format is provided, use the default format

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -2068,7 +2068,7 @@
 
         try {
             // if sprintf is passed a format it doesn't understand an exception is thrown
-            formatted = sprintf(format, result);
+            formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -3336,7 +3336,7 @@ if (typeof exports !== 'undefined') {
 
         try {
             // if sprintf is passed a format it doesn't understand an exception is thrown
-            formatted = sprintf(format, result);
+            formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28749
If there's no format provided (some data points don't specify one), use the default number format.  Without this, an empty string is returned resulting in empty lower legend values.  If the provided format is invalid, we'll still raise an error and use the default number format.