### PR TITLE
Feature/zen 28375

### DIFF
--- a/central-query/src/main/etc/configuration.yaml
+++ b/central-query/src/main/etc/configuration.yaml
@@ -12,7 +12,7 @@ metrics:
   defaultTsdTimeZone: UTC
   connectionTimeoutMs: 20000
   sendRateOptions: false
-
+  ignoreRateOption: true
   # parameters to configure connection pool for querying OpenTsdb:
   # Total connections allowed per pool
   maxTotalPoolConnections: 100

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/configs/MetricServiceConfig.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/configs/MetricServiceConfig.java
@@ -87,7 +87,7 @@ public class MetricServiceConfig {
     private int dropCacheTries = 5;
 
     @JsonProperty
-    private boolean ignoreRateOption = true;
+    private boolean ignoreRateOption = false;
 
     @JsonProperty
     private long rateOptionCutoffTs = -1;

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/configs/MetricServiceConfig.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/configs/MetricServiceConfig.java
@@ -86,6 +86,12 @@ public class MetricServiceConfig {
     @JsonProperty
     private int dropCacheTries = 5;
 
+    @JsonProperty
+    private boolean ignoreRateOption = true;
+
+    @JsonProperty
+    private long rateOptionCutoffTs = -1;
+
     public int getMaxTotalPoolConnections() {
         return maxTotalPoolConnections;
     }
@@ -277,4 +283,29 @@ public class MetricServiceConfig {
     public int getDropCacheTries() {
         return dropCacheTries;
     }
+
+    /**
+     * Ignore option to treat metric as a rate.
+     * @return
+     */
+    public boolean isIgnoreRateOption() {
+        return ignoreRateOption;
+    }
+
+    public void setIgnoreRateOption(boolean ignoreRateOption) {
+        this.ignoreRateOption = ignoreRateOption;
+    }
+
+    /**
+     * unix timestamp of when the rate storage changed
+     * @return
+     */
+    public long getRateOptionCutoffTs() {
+        return rateOptionCutoffTs;
+    }
+
+    public void setRateOptionCutoffTs(long rateOptionCutoffTs) {
+        this.rateOptionCutoffTs = rateOptionCutoffTs;
+    }
+
 }

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBClient.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBClient.java
@@ -11,6 +11,7 @@
 package org.zenoss.app.metricservice.api.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Ordering;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
@@ -27,8 +28,8 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Map;
+import java.text.ParseException;
+import java.util.*;
 
 public class OpenTSDBClient {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(OpenTSDBClient.class);
@@ -43,14 +44,14 @@ public class OpenTSDBClient {
         this.providedURL = url;
     }
 
-    public SuggestResult suggest(OpenTSDBSuggest suggest){
+    public SuggestResult suggest(OpenTSDBSuggest suggest) {
         final BasicHttpContext context = new BasicHttpContext();
         final HttpPost httpPost = new HttpPost(providedURL);
         final String jsonQueryString = Utils.jsonStringFromObject(suggest);
         StringEntity input;
-        try{
+        try {
             input = new StringEntity(jsonQueryString);
-        } catch (UnsupportedEncodingException e){
+        } catch (UnsupportedEncodingException e) {
             log.error("UnsupportedEncodingException converting json string {} to StringEntity: {}", jsonQueryString, e.getMessage());
             throw new IllegalArgumentException("Could not create StringEntity from query.", e);
         }
@@ -70,7 +71,7 @@ public class OpenTSDBClient {
         return result;
     }
 
-    public DropResult dropCache(String dropCacheUrl){
+    public DropResult dropCache(String dropCacheUrl) {
         final BasicHttpContext context = new BasicHttpContext();
         final HttpGet httpDrop = new HttpGet(dropCacheUrl);
         final HttpResponse dropResponse;
@@ -95,9 +96,9 @@ public class OpenTSDBClient {
         final HttpPost httpPost = new HttpPost(providedURL);
         final String jsonQueryString = Utils.jsonStringFromObject(rename);
         StringEntity input;
-        try{
+        try {
             input = new StringEntity(jsonQueryString);
-        } catch (UnsupportedEncodingException e){
+        } catch (UnsupportedEncodingException e) {
             log.error("UnsupportedEncodingException converting json string {} to StringEntity: {}", jsonQueryString, e.getMessage());
             throw new IllegalArgumentException("Could not create StringEntity from query.", e);
         }
@@ -121,10 +122,124 @@ public class OpenTSDBClient {
         return result;
     }
 
-    public OpenTSDBQueryReturn query(OpenTSDBQuery query) {
+    public OpenTSDBQueryReturn query(OpenTSDBQuery query, boolean ignoreRateOption, long rateCutoffDate) {
+        ArrayList<OpenTSDBQueryReturn> results = new ArrayList<>();
+        if (ignoreRateOption) {
+            boolean spansCutoff = false;
+            try {
+                long startTs = Utils.parseDate(query.start);
+                long endTs = Utils.parseDate(query.end);
+
+                if (rateCutoffDate > startTs && rateCutoffDate < endTs) {
+                    spansCutoff = true;
+                }
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+
+            ArrayList<OpenTSDBSubQuery> cutoffQueries = new ArrayList<>();
+            Iterator<OpenTSDBSubQuery> iter = query.queries.iterator();
+            // find rate queries and remove if spanning cutoff otherwise just remove rate option
+            while (iter.hasNext()) {
+                OpenTSDBSubQuery q = iter.next();
+                if (q.rate) {
+                    if (spansCutoff) {
+                        cutoffQueries.add(q);
+                        iter.remove();
+                    } else {
+                        q.rate = false;
+                    }
+                }
+            }
+            if (cutoffQueries.size() > 0) {
+                //we have rate queries and they span the cutoff date
+                //create a new query, one for pre cutoff and one for post cutoff
+                //if original query still has sub queries (gauges) make that request as well
+                ArrayList<OpenTSDBQueryReturn> responses = new ArrayList<>(2);
+                for (OpenTSDBSubQuery q : cutoffQueries) {
+                    OpenTSDBQuery preCutoff = new OpenTSDBQuery();
+                    preCutoff.start = query.start;
+                    preCutoff.end = String.valueOf(rateCutoffDate);
+
+                    OpenTSDBQuery postCutoff = new OpenTSDBQuery();
+                    postCutoff.start = String.valueOf(rateCutoffDate);
+                    postCutoff.end = query.end;
+
+                    preCutoff.addSubQuery(q);
+                    OpenTSDBSubQuery postQ = new OpenTSDBSubQuery();
+                    //post cutoff queries are stored as already calculated rates
+                    postQ.rate = false;
+                    postQ.rateOptions = q.rateOptions;
+                    postQ.aggregator = q.aggregator;
+                    postQ.metric = q.metric;
+                    postQ.downsample = q.downsample;
+                    postQ.tags = q.tags;
+                    postQ.filters = q.filters;
+                    postCutoff.addSubQuery(postQ);
+
+                    OpenTSDBQueryReturn preResult = this.query(preCutoff);
+                    if (preResult.getStatus().getStatus() == QueryStatus.QueryStatusEnum.ERROR) {
+                        return preResult;
+                    }
+                    OpenTSDBQueryReturn postResult = this.query(postCutoff);
+                    if (postResult.getStatus().getStatus() == QueryStatus.QueryStatusEnum.ERROR) {
+                        return postResult;
+                    }
+                    results.add(this.mergeResults(preResult, postResult));
+                    responses.clear();
+                }
+            }
+        }
+        if (!query.queries.isEmpty()) {
+            OpenTSDBQueryReturn result = this.query(query);
+            if (result.getStatus().getStatus() == QueryStatus.QueryStatusEnum.ERROR) {
+                return result;
+            }
+            results.add(result);
+        }
+        return this.combine(results);
+    }
+
+    private OpenTSDBQueryReturn combine(Collection<OpenTSDBQueryReturn> results) {
+        if (results.size() == 1) {
+            return results.iterator().next();
+        }
+
+        ArrayList<OpenTSDBQueryResult> combined = new ArrayList<>();
+        for( OpenTSDBQueryReturn x : results){
+            combined.addAll(x.getResults());
+        }
+        OpenTSDBQueryResult[] finalResults = combined.toArray(new OpenTSDBQueryResult[results.size()]);
+        return new OpenTSDBQueryReturn(finalResults, new QueryStatus(QueryStatus.QueryStatusEnum.SUCCESS, ""));
+    }
+
+    private OpenTSDBQueryReturn mergeResults(OpenTSDBQueryReturn preCutoff, OpenTSDBQueryReturn postCutoff) {
+        //Join the results of one metric query that has been split,
+        // every query can return multiple results so make a key from the metricname and aggregated tags
+        Map<String, OpenTSDBQueryResult> results = new HashMap<>();
+        OpenTSDBQueryReturn[] both = new OpenTSDBQueryReturn[]{preCutoff, postCutoff};
+        for (OpenTSDBQueryReturn input : both) {
+            for (OpenTSDBQueryResult x : input.getResults()) {
+                TreeMap<String, String> tags = new TreeMap<>(x.tags);
+                String key = x.metric + tags;
+                if (!results.containsKey(key)) {
+                    results.put(key, x);
+                } else {
+                    results.get(key).getDataPoints().putAll(x.getDataPoints());
+                }
+            }
+        }
+        OpenTSDBQueryResult[] finalResults = results.values().toArray(new OpenTSDBQueryResult[results.size()]);
+        return new OpenTSDBQueryReturn(finalResults, new QueryStatus(QueryStatus.QueryStatusEnum.SUCCESS, ""));
+    }
+
+    private OpenTSDBQueryReturn query(OpenTSDBQuery query) {
         final BasicHttpContext context = new BasicHttpContext();
         final HttpPost httpPost = new HttpPost(providedURL);
+
         final String jsonQueryString = Utils.jsonStringFromObject(query);
+        log.info("JPL query");
+        log.info(jsonQueryString);
         StringEntity input;
         try {
             input = new StringEntity(jsonQueryString);
@@ -150,7 +265,7 @@ public class OpenTSDBClient {
                     log.info("Response code {}, message: {}", tsdbResponse.error.code, tsdbResponse.error.message);
                     log.debug("Response object: {}", Utils.jsonStringFromObject(tsdbResponse));
                     message = tsdbResponse.error.message;
-                }else{
+                } else {
                     log.info("HTTP Execute returned status {}. Reason: {}", status.getStatusCode(), status.getReasonPhrase());
                 }
                 queryStatus = new QueryStatus(QueryStatus.QueryStatusEnum.ERROR, message);

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBClient.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBClient.java
@@ -238,8 +238,6 @@ public class OpenTSDBClient {
         final HttpPost httpPost = new HttpPost(providedURL);
 
         final String jsonQueryString = Utils.jsonStringFromObject(query);
-        log.info("JPL query");
-        log.info(jsonQueryString);
         StringEntity input;
         try {
             input = new StringEntity(jsonQueryString);

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
@@ -225,13 +225,9 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         OpenTSDBClient renameClient =
                 new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiRenameUrl());
         OpenTSDBClient dropCacheClient =
-<<<<<<< 4382c945a0cf46793aaf6de6ce010f12be05aa7c
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropCacheUrl());
         OpenTSDBClient dropWriterCacheClient =
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropWriterCacheUrl());
-=======
-                new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropCacheUrl());
->>>>>>> WIP. Done except for cleanup
 
         final String type = renameRequest.getType();
         final String oldName = renameRequest.getOldName();

--- a/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
+++ b/central-query/src/main/java/org/zenoss/app/metricservice/api/impl/OpenTSDBMetricStorage.java
@@ -52,7 +52,6 @@ import org.zenoss.app.metricservice.api.model.v2.*;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -92,13 +91,14 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
     @Override
     public void renamePrefix(RenameRequest renameRequest, Writer writer) {
         OpenTSDBClient renameClient =
-            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiRenameUrl());
+                new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiRenameUrl());
         OpenTSDBClient suggestClient =
-            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiSuggestUrl());
+                new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiSuggestUrl());
         OpenTSDBClient dropCacheClient =
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropCacheUrl());
         OpenTSDBClient dropWriterCacheClient =
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropWriterCacheUrl());
+
 
         final String oldPrefix = renameRequest.getOldName();
         final String newPrefix = renameRequest.getNewName();
@@ -106,7 +106,7 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
 
         ExecutorService executorService = getExecutorService();
         CompletionService<RenameResult> renameCompletionService =
-            new ExecutorCompletionService<>(executorService);
+                new ExecutorCompletionService<>(executorService);
 
         OpenTSDBSuggest otsdbSuggestRequest = new OpenTSDBSuggest();
 
@@ -120,7 +120,7 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         SuggestResult suggestResult = suggestClient.suggest(otsdbSuggestRequest);
         ArrayList<String> suggestions = suggestResult.suggestions;
 
-        for(String s: suggestions){
+        for (String s : suggestions) {
             String replace = s.replaceFirst(oldPrefix, newPrefix);
             final OpenTSDBRename renameReq = new OpenTSDBRename();
 
@@ -142,19 +142,19 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
                 final Future<RenameResult> result = renameCompletionService.take();
 
                 // Write the progress.
-                int percent = (int) ((float) i/nTasks*100);
+                int percent = (int) ((float) i / nTasks * 100);
 
                 msg.setType(RenameLogMsg.TYPE_PROGRESS);
                 msg.setContent(
-                    String.format(
-                        "Renaming %s prefix %s to %s: %d out of %d tasks completed (%d%%).",
-                        type,
-                        oldPrefix,
-                        newPrefix,
-                        i,
-                        nTasks,
-                        percent
-                    )
+                        String.format(
+                                "Renaming %s prefix %s to %s: %d out of %d tasks completed (%d%%).",
+                                type,
+                                oldPrefix,
+                                newPrefix,
+                                i,
+                                nTasks,
+                                percent
+                        )
                 );
 
                 writer.write(Utils.jsonStringFromObject(msg) + "\n");
@@ -171,13 +171,13 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
 
                     msg.setType(RenameLogMsg.TYPE_ERROR);
                     msg.setContent(
-                        String.format(
-                            "Error while renaming %s prefix %s to %s in OpenTSDB: %s",
-                            type,
-                            oldName,
-                            newName,
-                            r.reason
-                        )
+                            String.format(
+                                    "Error while renaming %s prefix %s to %s in OpenTSDB: %s",
+                                    type,
+                                    oldName,
+                                    newName,
+                                    r.reason
+                            )
                     );
 
                     log.error(msg.getContent());
@@ -185,27 +185,27 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
                 }
             } catch (InterruptedException e) {
                 log.error(
-                    "Error while processing a renaming task result: {}",
-                    e.getMessage()
+                        "Error while processing a renaming task result: {}",
+                        e.getMessage()
                 );
             } catch (ExecutionException e) {
                 log.error(
-                    "Error while processing a renaming task result: {}",
-                    e.getMessage()
+                        "Error while processing a renaming task result: {}",
+                        e.getMessage()
                 );
             } catch (IOException e) {
                 log.error(
-                    "Error while writing the progress of renaming tasks: {}",
-                    e.getMessage()
+                        "Error while writing the progress of renaming tasks: {}",
+                        e.getMessage()
                 );
             }
         }
 
         log.info(
-            "Renaming {} prefix {} to {} completed.",
-            type,
-            oldPrefix,
-            newPrefix
+                "Renaming {} prefix {} to {} completed.",
+                type,
+                oldPrefix,
+                newPrefix
         );
 
         // No. of dropcache calls to make after renaming.
@@ -223,11 +223,15 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
     @Override
     public void renameWhole(RenameRequest renameRequest, Writer writer) {
         OpenTSDBClient renameClient =
-            new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiRenameUrl());
+                new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiRenameUrl());
         OpenTSDBClient dropCacheClient =
+<<<<<<< 4382c945a0cf46793aaf6de6ce010f12be05aa7c
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropCacheUrl());
         OpenTSDBClient dropWriterCacheClient =
             new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropWriterCacheUrl());
+=======
+                new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiDropCacheUrl());
+>>>>>>> WIP. Done except for cleanup
 
         final String type = renameRequest.getType();
         final String oldName = renameRequest.getOldName();
@@ -244,15 +248,15 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
 
         RenameResult renameResult = new RenameResult();
         RenameLogMsg msg = new RenameLogMsg();
-        for(int x = 0; x < RETRY_CT; x++){
+        for (int x = 0; x < RETRY_CT; x++) {
             renameResult = renameClient.rename(otsdbRenameRequest);
-            if(renameResult.code == 200){
+            if (renameResult.code == 200) {
                 msg.setType(RenameLogMsg.TYPE_INFO);
                 msg.setContent(String.format(
-                    "Renaming %s %s to %s completed.",
-                    type,
-                    oldName,
-                    newName
+                        "Renaming %s %s to %s completed.",
+                        type,
+                        oldName,
+                        newName
                 ));
                 log.info(msg.getContent());
                 try {
@@ -261,7 +265,7 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
                     log.error("Error while handling IO after renaming in central query");
                 }
                 break;
-            } else if(renameResult.code < 500){
+            } else if (renameResult.code < 500) {
                 break; // shouldn't retry on 400-level statuses
             }
         }
@@ -269,19 +273,19 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         if (!(renameResult.code >= 200 && renameResult.code <= 299)) {
             msg.setType(RenameLogMsg.TYPE_ERROR);
             msg.setContent(String.format(
-                "Error while renaming %s %s to %s in OpenTSDB: %s",
-                type,
-                oldName,
-                newName,
-                renameResult.reason
+                    "Error while renaming %s %s to %s in OpenTSDB: %s",
+                    type,
+                    oldName,
+                    newName,
+                    renameResult.reason
             ));
             log.error(msg.getContent());
             try {
                 writer.write(Utils.jsonStringFromObject(msg));
             } catch (IOException e) {
                 log.error(
-                    "Error while handling IO after renaming in central query: {}",
-                    e.getMessage());
+                        "Error while handling IO after renaming in central query: {}",
+                        e.getMessage());
             }
         }
 
@@ -305,11 +309,11 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         @Override
         public RenameResult call() {
             RenameResult renameResult = new RenameResult();
-            for(int x = 0; x < RETRY_CT; x++){
+            for (int x = 0; x < RETRY_CT; x++) {
                 renameResult = client.rename(renameReq);
-                if(renameResult.code == 200){
+                if (renameResult.code == 200) {
                     break;
-                } else if(renameResult.code < 500){
+                } else if (renameResult.code < 500) {
                     break; // shouldn't retry on 400-level statuses
                 }
             }
@@ -337,7 +341,7 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         }
 
         OpenTSDBClient client = new OpenTSDBClient(this.getHttpClient(), getOpenTSDBApiQueryUrl());
-        OpenTSDBQueryReturn result = client.query(otsdbQuery);
+        OpenTSDBQueryReturn result = client.query(otsdbQuery, this.config.getMetricServiceConfig().isIgnoreRateOption(), this.config.getMetricServiceConfig().getRateOptionCutoffTs());
         for (OpenTSDBQueryResult series : result.getResults()) {
             series.metric = series.metric.replace(SPACE_REPLACEMENT, " ");
         }
@@ -382,13 +386,16 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
     private String getOpenTSDBApiQueryUrl() {
         return String.format("%s/api/query", config.getMetricServiceConfig().getOpenTsdbUrl());
     }
-    private String getOpenTSDBApiSuggestUrl(){
+
+    private String getOpenTSDBApiSuggestUrl() {
         return String.format("%s/api/suggest", config.getMetricServiceConfig().getOpenTsdbUrl());
     }
+
     private String getOpenTSDBApiRenameUrl() {
         return String.format("%s/api/uid/rename", config.getMetricServiceConfig().getOpenTsdbUrl());
     }
-    private String getOpenTSDBApiDropCacheUrl(){
+
+    private String getOpenTSDBApiDropCacheUrl() {
         return String.format("%s/api/dropcaches", config.getMetricServiceConfig().getOpenTsdbUrl());
     }
     private String getOpenTSDBApiDropWriterCacheUrl(){
@@ -416,18 +423,17 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
             // ignore any tags.  Otherwise we process the tags.
             List<Filter> filters = mq.getFilters();
             if (null != filters && !filters.isEmpty()) {
-                for(Filter filter : filters) {
+                for (Filter filter : filters) {
                     result.addFilter(
-                        new OpenTSDBFilter(
-                            filter.getType(),
-                            Tags.sanitizeKey(filter.getTagk()),
-                            filter.getFilter(),
-                            filter.getGroupBy()
-                        )
+                            new OpenTSDBFilter(
+                                    filter.getType(),
+                                    Tags.sanitizeKey(filter.getTagk()),
+                                    filter.getFilter(),
+                                    filter.getGroupBy()
+                            )
                     );
                 }
-            }
-            else {
+            } else {
                 Map<String, List<String>> tags = mq.getTags();
                 if (null != tags) {
                     for (Map.Entry<String, List<String>> tagEntry : tags.entrySet()) {
@@ -480,7 +486,7 @@ public class OpenTSDBMetricStorage implements MetricStorageAPI {
         List<Callable<OpenTSDBQueryResult>> callables = new ArrayList<>(queries.size());
         DefaultHttpClient httpClient = getHttpClient();
         for (MetricSpecification mSpec : queries) {
-            MetricSpecCallable callable = new MetricSpecCallable(httpClient, start, end, mSpec, getOpenTSDBApiQueryUrl());
+            MetricSpecCallable callable = new MetricSpecCallable(httpClient, start, end, mSpec, getOpenTSDBApiQueryUrl(), this.config.getMetricServiceConfig().isIgnoreRateOption(), this.config.getMetricServiceConfig().getRateOptionCutoffTs());
             callables.add(callable);
         }
         List<Future<OpenTSDBQueryResult>> futures = invokeCallables(callables);

--- a/central-query/src/test/resources/ignorerateoptionquery/otsdbInteraction.json
+++ b/central-query/src/test/resources/ignorerateoptionquery/otsdbInteraction.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "start": "1437520683",
+    "end": "1437521231",
+    "queries": [
+      {
+        "aggregator": "avg",
+        "metric": "cgroup.cpuacct.user",
+        "rate": false,
+        "rateOptions": {
+          "counter": true,
+          "counterMax": 9223372036854775807,
+          "resetValue": 1234,
+          "dropResets": true
+        },
+        "tags": {
+          "isvcname": "elasticsearch-serviced"
+        }
+      }
+    ],
+    "noAnnotations": false,
+    "globalAnnotations": false,
+    "msResolution": false,
+    "showTSUIDs": false
+  },
+  "response": [
+    {
+      "metric": "cgroup.cpuacct.user",
+      "tags": {
+        "isvc": "true",
+        "isvcname": "elasticsearch-serviced"
+      },
+      "aggregateTags": [],
+      "dps": {
+        "1437520683": 107561.0,
+        "1437521223": 107714.0
+      }
+    }
+  ]
+}
+

--- a/central-query/src/test/resources/ignorerateoptionquery/request.json
+++ b/central-query/src/test/resources/ignorerateoptionquery/request.json
@@ -1,0 +1,21 @@
+{
+  "start": "1437520683",
+  "end": "1437521231",
+  "queries": [
+    {
+      "metric": "cgroup.cpuacct.user",
+      "rate": true,
+       "rateOptions": {
+          "counter": true,
+          "counterMax": 9223372036854775807,
+          "resetThreshold": 1234,
+          "dropResets": true
+       },
+      "tags": {
+        "isvcname": [
+          "elasticsearch-serviced"
+        ]
+      }
+    }
+  ]
+}

--- a/central-query/src/test/resources/ignorerateoptionquery/result.json
+++ b/central-query/src/test/resources/ignorerateoptionquery/result.json
@@ -1,0 +1,27 @@
+{
+  "series": [
+    {
+      "datapoints": [
+        [
+          1437520683,
+          107561.0
+        ],
+        [
+          1437521223,
+          107714.0
+        ]
+      ],
+      "metric": "cgroup.cpuacct.user",
+      "tags": {
+        "isvc": "true",
+        "isvcname": "elasticsearch-serviced"
+      }
+    }
+  ],
+  "statuses": [
+    {
+      "message": "",
+      "status": "SUCCESS"
+    }
+  ]
+}

--- a/central-query/src/test/resources/spancutoff/gauge-otsdbInteraction.json
+++ b/central-query/src/test/resources/spancutoff/gauge-otsdbInteraction.json
@@ -1,0 +1,44 @@
+{
+  "request": {
+    "start": "1437520683",
+    "end": "1437521231",
+    "queries": [
+      {
+        "aggregator": "avg",
+        "metric": "cgroup.cpuacct.system",
+        "rate": false,
+        "rateOptions": {
+          "counter": false,
+          "counterMax": 9223372036854775807,
+          "resetValue": 0,
+          "dropResets": false
+        },
+        "tags": {
+          "isvcname": "elasticsearch-serviced"
+        }
+      }
+    ],
+    "noAnnotations": false,
+    "globalAnnotations": false,
+    "msResolution": false,
+    "showTSUIDs": false
+  },
+  "response": [
+    {
+      "metric": "cgroup.cpuacct.system",
+      "tags": {
+        "isvc": "true",
+        "isvcname": "elasticsearch-serviced"
+      },
+      "aggregateTags": [],
+      "dps": {
+        "1437520763": 59288.0,
+        "1437520773": 59289.0,
+        "1437520783": 59290.0,
+        "1437520793": 59292.0,
+        "1437520803": 59294.0,
+        "1437520813": 59297.0
+      }
+    }
+  ]
+}

--- a/central-query/src/test/resources/spancutoff/postcutoff-otsdbInteraction.json
+++ b/central-query/src/test/resources/spancutoff/postcutoff-otsdbInteraction.json
@@ -1,0 +1,40 @@
+{
+  "request": {
+    "start": "1437520981",
+    "end": "1437521231",
+    "queries": [
+      {
+        "aggregator": "avg",
+        "metric": "cgroup.cpuacct.user",
+        "rate": false,
+        "rateOptions": {
+          "counter": true,
+          "counterMax": 9223372036854775807,
+          "resetValue": 1234,
+          "dropResets": true
+        },
+        "tags": {
+          "isvcname": "elasticsearch-serviced"
+        }
+      }
+    ],
+    "noAnnotations": false,
+    "globalAnnotations": false,
+    "msResolution": false,
+    "showTSUIDs": false
+  },
+  "response": [
+    {
+      "metric": "cgroup.cpuacct.user",
+      "tags": {
+        "isvc": "true",
+        "isvcname": "elasticsearch-serviced"
+      },
+      "aggregateTags": [],
+      "dps": {
+        "1437521223": 107714.0
+      }
+    }
+  ]
+}
+

--- a/central-query/src/test/resources/spancutoff/precutoff-otsdbInteraction.json
+++ b/central-query/src/test/resources/spancutoff/precutoff-otsdbInteraction.json
@@ -1,0 +1,40 @@
+{
+  "request": {
+    "start": "1437520683",
+    "end": "1437520981",
+    "queries": [
+      {
+        "aggregator": "avg",
+        "metric": "cgroup.cpuacct.user",
+        "rate": true,
+        "rateOptions": {
+          "counter": true,
+          "counterMax": 9223372036854775807,
+          "resetValue": 1234,
+          "dropResets": true
+        },
+        "tags": {
+          "isvcname": "elasticsearch-serviced"
+        }
+      }
+    ],
+    "noAnnotations": false,
+    "globalAnnotations": false,
+    "msResolution": false,
+    "showTSUIDs": false
+  },
+  "response": [
+    {
+      "metric": "cgroup.cpuacct.user",
+      "tags": {
+        "isvc": "true",
+        "isvcname": "elasticsearch-serviced"
+      },
+      "aggregateTags": [],
+      "dps": {
+        "1437520683": 107561.0
+      }
+    }
+  ]
+}
+

--- a/central-query/src/test/resources/spancutoff/request.json
+++ b/central-query/src/test/resources/spancutoff/request.json
@@ -1,0 +1,30 @@
+{
+  "start": "1437520683",
+  "end": "1437521231",
+  "queries": [
+    {
+      "metric": "cgroup.cpuacct.user",
+      "rate": true,
+       "rateOptions": {
+          "counter": true,
+          "counterMax": 9223372036854775807,
+          "resetThreshold": 1234,
+          "dropResets": true
+       },
+      "tags": {
+        "isvcname": [
+          "elasticsearch-serviced"
+        ]
+      }
+    },
+    {
+      "metric": "cgroup.cpuacct.system",
+      "rate": false,
+      "tags": {
+        "isvcname": [
+          "elasticsearch-serviced"
+        ]
+      }
+    }
+  ]
+}

--- a/central-query/src/test/resources/spancutoff/result.json
+++ b/central-query/src/test/resources/spancutoff/result.json
@@ -1,0 +1,64 @@
+{
+  "series": [
+    {
+      "datapoints": [
+        [
+          1437520683,
+          107561.0
+        ],
+        [
+          1437521223,
+          107714.0
+        ]
+      ],
+      "metric": "cgroup.cpuacct.user",
+      "tags": {
+        "isvc": "true",
+        "isvcname": "elasticsearch-serviced"
+      }
+    },
+    {
+      "datapoints": [
+        [
+          1437520763,
+          59288.0
+        ],
+        [
+          1437520773,
+          59289.0
+        ],
+        [
+          1437520783,
+          59290.0
+        ],
+        [
+          1437520793,
+          59292.0
+        ],
+        [
+          1437520803,
+          59294.0
+        ],
+        [
+          1437520813,
+          59297.0
+        ]
+      ],
+      "metric": "cgroup.cpuacct.system",
+      "tags": {
+        "isvc": "true",
+        "isvcname": "elasticsearch-serviced"
+      }
+    }
+  ],
+  "statuses": [
+    {
+      "message": "",
+      "status": "SUCCESS"
+    },
+    {
+      "message": "",
+      "status": "SUCCESS"
+    }
+  ]
+}


### PR DESCRIPTION
Add `ignoreRateOption` option to ignore request options for treating metrics as rates, this option assumes data is already saved as rates.  Also a `rateOptionCutoffTs` setting used in conjunction with `ignoreRateOption`. When the timestamp is set, any rate query that fall before the timestamp will honor the rate options. If a query spans the cutoff timestamp, two queries will be made and the results will be joined.