### PR TITLE
ZEN-28965: skip preferredUnit when formatting gives zero

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -2069,9 +2069,15 @@
         try {
             // if sprintf is passed a format it doesn't understand an exception is thrown
             formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
+            if ((Number(formatted) === 0) && val){
+                return toEng(val, undefined, format, base, skipCalc)
+            }
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);
+            if ((Number(formatted) === 0) && val){
+                return  toEng(val, undefined, format, base, skipCalc)
+            }
         }
 
         // TODO - make graph y axis capable of expanding to

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -3337,9 +3337,15 @@ if (typeof exports !== 'undefined') {
         try {
             // if sprintf is passed a format it doesn't understand an exception is thrown
             formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
+            if ((Number(formatted) === 0) && val){
+                return toEng(val, undefined, format, base, skipCalc)
+            }
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);
+            if ((Number(formatted) === 0) && val ){
+                return toEng(val, undefined, format, base, skipCalc)
+            }
         }
 
         // TODO - make graph y axis capable of expanding to


### PR DESCRIPTION
If the difference between value of two data point is huge
a lower value will be formatted to units of higher and give
a zero.
Skip preferredUnit if formatting gives a zero value.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-28965)