### PR TITLE
ZEN-29235 Narrow browser charts

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -49,7 +49,7 @@
             ticks: 4,
             breakpoint: 20,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format("HH:mm:ss");
+                return moment.utc(d).tz(tz).format("HH:mm");
             }
         }, {
             name: "day",
@@ -57,7 +57,7 @@
             ticks: 3,
             breakpoint: 7,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }, {
             name: "week",
@@ -65,7 +65,7 @@
             ticks: 3,
             breakpoint: 4,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }, {
             name: "month",
@@ -73,7 +73,7 @@
             ticks: 3,
             breakpoint: 13,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }, {
             name: "year",
@@ -82,7 +82,7 @@
             ticks: 3,
             breakpoint: 1000,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }
     ];
@@ -292,39 +292,38 @@
          * footer, and then resizes the underlying chart.
          */
         resize: function () {
-            var theight, fheight, height, span;
-
             var $footer = this.$div.find(".zenfooter");
             var $title = this.$div.find(".graph_title");
+            var $gphBody = this.$div.find("[id$=_graph-body]");
 
-            theight = parseInt($title.outerHeight(), 10);
-            fheight = this.__hasFooter() ? parseInt($footer.outerHeight(), 10) : 0;
-            height = parseInt(this.$div.height(), 10) - fheight - theight;
-            span = $(this.message).find('span');
+            var theight = parseInt($title.outerHeight(), 10);
+            var fheight = this.__hasFooter() ? parseInt($footer.outerHeight(), 10) : 0;
+            var height = parseInt(this.$div.height(), 10) - fheight - theight;
+            var span = $(this.message).find('span');
 
             // resize wrapper to ensure enough space for graph
             $(this.svgwrapper).outerHeight(height);
 
             // ZEN-29235 enforce minimum chart width to prevent squished chart
-            var minChartWidth = 480;
+            var svgw = $(this.svgwrapper).width();
+            var minChartWidth = Math.max(svgw, 480);
+            $(this.svgwrapper).width(minChartWidth);
+
             var cols = Math.max(1, Zenoss.settings.graphColumns);
             var minColsWrapWidth = (minChartWidth + 30) * cols + 40;
-            var gphBody = $('#device_graphs-body, #device_component_graphs-body').width() - 20;
-            var colsWrapWidth = Math.max(gphBody, minColsWrapWidth);
+            var gphBodyWidth = $gphBody.width() - 20;
+            var colsWrapWidth = Math.max(gphBodyWidth, minColsWrapWidth);
 
-            var zGraphColsWrap = $('#device_graphs-body > div:first-child, #device_component_graphs-body > div:first-child');
+            var zGraphColsWrap = $('[id$=_graphs-body] > div:first-child');
             zGraphColsWrap.addClass('z-graph-cols-wrap').width(colsWrapWidth);
-
-            var svgw = $(this.svgwrapper).width();
-            var svgwrap = Math.max(svgw, minChartWidth);
-            $(this.svgwrapper).width(svgwrap);
 
             // component graphs need a tad extra help overriding
             // injected styles both for stretching and squeezing
-            if (gphBody > minColsWrapWidth) {
+            if (gphBodyWidth > minColsWrapWidth) {
                 $('#device_component_graphs-innerCt').removeAttr('style');
             } else {
                 $('#device_component_graphs-body .x-column, #device_component_graphs-body .x-panel-body').removeAttr('style');
+                $('#device_graphs-innerCt .x-column, #device_component_graphs-innerCt .x-column').width(minChartWidth);
             }
 
             if (this.impl) {
@@ -1874,7 +1873,7 @@
          * @access public
          * @default "MM/DD/YY HH:mm:ss"
          */
-        dateFormat: DATE_FORMAT + " HH:mm:ss",
+        dateFormat: DATE_FORMAT + " HH:mm",
 
         // uses TIME_DATA to determine which time range we care about
         // and format labels representative of that time range

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -1317,7 +1317,7 @@ if (typeof exports !== 'undefined') {
             ticks: 4,
             breakpoint: 20,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format("HH:mm:ss");
+                return moment.utc(d).tz(tz).format("HH:mm");
             }
         }, {
             name: "day",
@@ -1325,7 +1325,7 @@ if (typeof exports !== 'undefined') {
             ticks: 3,
             breakpoint: 7,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }, {
             name: "week",
@@ -1333,7 +1333,7 @@ if (typeof exports !== 'undefined') {
             ticks: 3,
             breakpoint: 4,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }, {
             name: "month",
@@ -1341,7 +1341,7 @@ if (typeof exports !== 'undefined') {
             ticks: 3,
             breakpoint: 13,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }, {
             name: "year",
@@ -1350,7 +1350,7 @@ if (typeof exports !== 'undefined') {
             ticks: 3,
             breakpoint: 1000,
             format: function (tz, d) {
-                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm:ss");
+                return moment.utc(d).tz(tz).format(DATE_FORMAT + " HH:mm");
             }
         }
     ];
@@ -1560,39 +1560,38 @@ if (typeof exports !== 'undefined') {
          * footer, and then resizes the underlying chart.
          */
         resize: function () {
-            var theight, fheight, height, span;
-
             var $footer = this.$div.find(".zenfooter");
             var $title = this.$div.find(".graph_title");
+            var $gphBody = this.$div.find("[id$=_graph-body]");
 
-            theight = parseInt($title.outerHeight(), 10);
-            fheight = this.__hasFooter() ? parseInt($footer.outerHeight(), 10) : 0;
-            height = parseInt(this.$div.height(), 10) - fheight - theight;
-            span = $(this.message).find('span');
+            var theight = parseInt($title.outerHeight(), 10);
+            var fheight = this.__hasFooter() ? parseInt($footer.outerHeight(), 10) : 0;
+            var height = parseInt(this.$div.height(), 10) - fheight - theight;
+            var span = $(this.message).find('span');
 
             // resize wrapper to ensure enough space for graph
             $(this.svgwrapper).outerHeight(height);
 
             // ZEN-29235 enforce minimum chart width to prevent squished chart
-            var minChartWidth = 480;
+            var svgw = $(this.svgwrapper).width();
+            var minChartWidth = Math.max(svgw, 480);
+            $(this.svgwrapper).width(minChartWidth);
+
             var cols = Math.max(1, Zenoss.settings.graphColumns);
             var minColsWrapWidth = (minChartWidth + 30) * cols + 40;
-            var gphBody = $('#device_graphs-body, #device_component_graphs-body').width() - 20;
-            var colsWrapWidth = Math.max(gphBody, minColsWrapWidth);
+            var gphBodyWidth = $gphBody.width() - 20;
+            var colsWrapWidth = Math.max(gphBodyWidth, minColsWrapWidth);
 
-            var zGraphColsWrap = $('#device_graphs-body > div:first-child, #device_component_graphs-body > div:first-child');
+            var zGraphColsWrap = $('[id$=_graphs-body] > div:first-child');
             zGraphColsWrap.addClass('z-graph-cols-wrap').width(colsWrapWidth);
-
-            var svgw = $(this.svgwrapper).width();
-            var svgwrap = Math.max(svgw, minChartWidth);
-            $(this.svgwrapper).width(svgwrap);
 
             // component graphs need a tad extra help overriding
             // injected styles both for stretching and squeezing
-            if (gphBody > minColsWrapWidth) {
+            if (gphBodyWidth > minColsWrapWidth) {
                 $('#device_component_graphs-innerCt').removeAttr('style');
             } else {
                 $('#device_component_graphs-body .x-column, #device_component_graphs-body .x-panel-body').removeAttr('style');
+                $('#device_graphs-innerCt .x-column, #device_component_graphs-innerCt .x-column').width(minChartWidth);
             }
 
             if (this.impl) {
@@ -3142,7 +3141,7 @@ if (typeof exports !== 'undefined') {
          * @access public
          * @default "MM/DD/YY HH:mm:ss"
          */
-        dateFormat: DATE_FORMAT + " HH:mm:ss",
+        dateFormat: DATE_FORMAT + " HH:mm",
 
         // uses TIME_DATA to determine which time range we care about
         // and format labels representative of that time range


### PR DESCRIPTION
Additional code to prevent chart squishing. Also: remove seconds from chart time values. Note: the gulp'd file visualization.js must be included for central query check-in.