### PR TITLE
ZEN-28901: update graph data despite bad Predictive Threshold

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -1129,7 +1129,11 @@
                         self.projections.forEach(function (projection) {
                             var projectionRequest = self.__buildProjectionRequest(self.config, self.request, projection);
                             // can fail if the projection is requesting a metric not present
+                            // but we still want to update graph with new data
                             if (!projectionRequest) {
+                                if (self.closure) {
+                                    self.__updateData(data);
+                                }
                                 return;
                             }
                             $.ajax({

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -2397,7 +2397,11 @@ if (typeof exports !== 'undefined') {
                         self.projections.forEach(function (projection) {
                             var projectionRequest = self.__buildProjectionRequest(self.config, self.request, projection);
                             // can fail if the projection is requesting a metric not present
+                            // but we still want to update graph with new data
                             if (!projectionRequest) {
+                                if (self.closure) {
+                                    self.__updateData(data);
+                                }
                                 return;
                             }
                             $.ajax({


### PR DESCRIPTION
If there was a datapoint in your predictive threshold that is not
on the Graph, it won't update when you change the range of time.
Update the Graph despite the fact that there is a bad Predictive
Threshold on it. There is no harm in having that Threshold on it.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-28901?focusedCommentId=122704&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-122704)