### PR TITLE
Fix ZEN-30524 recursive call to toEng

### DIFF
--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -2212,13 +2212,13 @@
             // if sprintf is passed a format it doesn't understand an exception is thrown
             formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, False)
+                return toEng(val, undefined, format, base, false)
             }
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, False)
+                return toEng(val, undefined, format, base, false)
             }
         }
 

--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -2212,13 +2212,13 @@
             // if sprintf is passed a format it doesn't understand an exception is thrown
             formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, skipCalc)
+                return toEng(val, undefined, format, base, False)
             }
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, skipCalc)
+                return toEng(val, undefined, format, base, False)
             }
         }
 

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -3544,13 +3544,13 @@ if (typeof exports !== 'undefined') {
             // if sprintf is passed a format it doesn't understand an exception is thrown
             formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, skipCalc)
+                return toEng(val, undefined, format, base, False)
             }
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, skipCalc)
+                return toEng(val, undefined, format, base, False)
             }
         }
 

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -3544,13 +3544,13 @@ if (typeof exports !== 'undefined') {
             // if sprintf is passed a format it doesn't understand an exception is thrown
             formatted = sprintf(format || DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, False)
+                return toEng(val, undefined, format, base, false)
             }
         } catch (err) {
             console.error("Invalid format", format, "using default", DEFAULT_NUMBER_FORMAT);
             formatted = sprintf(DEFAULT_NUMBER_FORMAT, result);
             if ((Number(formatted) === 0) && val){
-                return toEng(val, undefined, format, base, False)
+                return toEng(val, undefined, format, base, false)
             }
         }
 


### PR DESCRIPTION
Fix recursive call to toEng in visualization.js, to avoid infinite recursion described in ZEN-30524. Fix is simply: always set SkipCalc=False when doing the recursive call, which forces toEng to calculate an appropriate preferredUnit, so that the result can be expressed as a non-zero number.