### PR TITLE
ZEN-32720 Added LazyChartLoader

### DIFF
--- a/central-query/src/main/js/visualization/gulpfile.js
+++ b/central-query/src/main/js/visualization/gulpfile.js
@@ -28,6 +28,7 @@ gulp.task("build", function(){
             paths.src + "debug.js",
             paths.src + "dependency.js",
             paths.src + "visualization.js",
+            paths.src + "LazyChartLoader.js",
             paths.src + "Chart.js",
             paths.src + "outro.js",
         ])

--- a/central-query/src/main/js/visualization/src/Chart.js
+++ b/central-query/src/main/js/visualization/src/Chart.js
@@ -107,7 +107,7 @@
         [31536000000, '10d-avg']  // 1 Year
     ];
 
-
+    var lazyLoader = new LazyChartLoader(30);
     Chart = function (name, config) {
         this.name = name;
         this.config = config;
@@ -191,7 +191,7 @@
             if (this.request.metrics === undefined) {
                 debug.__warn('Chart configuration contains no metric sepcifications. No data will be displayed.');
             }
-            this.update();
+            lazyLoader.addChart(this);
         } catch (x) {
             debug.__error(x);
             this.__showError(x);

--- a/central-query/src/main/js/visualization/src/LazyChartLoader.js
+++ b/central-query/src/main/js/visualization/src/LazyChartLoader.js
@@ -1,0 +1,54 @@
+/**
+ * LazyChartLoader.js
+ */
+(function () {
+    "use strict";
+
+    /**
+     * This class is used for manage Chart loading. This class limits the number of graphs
+     * that make queries simultaneously. 
+     *
+     * @constructor
+     * @param maxParallelsCharts
+     *            the number of graphs that are loaded simultaneously
+     */
+
+    LazyChartLoader = function (maxParallelsCharts) {
+        this.maxParallelsCharts = maxParallelsCharts;
+        this.activeCall = 0;
+        this.chartQueue = [];
+    };
+
+    LazyChartLoader.prototype = {
+        constructor: LazyChartLoader,
+
+        addChart: function (chart) {
+            this.chartQueue.push(chart);
+            this.__checkQueue();
+        },
+
+        __onCompleteOrFailure: function () {
+            this.activeCall--;
+            this.__checkQueue();
+        },
+
+        __onChartUpdate: function (updatePromise) {
+            updatePromise.then(
+                this.__onCompleteOrFailure.bind(this),
+                this.__onCompleteOrFailure.bind(this)
+            );
+        },
+
+        __checkQueue: function () {
+            if (this.chartQueue.length && this.activeCall <= this.maxParallelsCharts) {
+                var chart = this.chartQueue.shift();
+                if (!chart) {
+                    return;
+                }
+                this.activeCall++;
+                chart.onUpdate = this.__onChartUpdate.bind(this);
+                chart.update();
+            }
+        }
+    }
+})();

--- a/central-query/src/main/js/visualization/src/intro.js
+++ b/central-query/src/main/js/visualization/src/intro.js
@@ -3,6 +3,7 @@
 // various thingies
 var visualization,
 	utils,
+	LazyChartLoader,
 	Chart,
 	debug,
 	dependency;

--- a/central-query/src/main/resources/api/visualization.js
+++ b/central-query/src/main/resources/api/visualization.js
@@ -3,6 +3,7 @@
 // various thingies
 var visualization,
 	utils,
+	LazyChartLoader,
 	Chart,
 	debug,
 	dependency;
@@ -1275,6 +1276,61 @@ if (typeof exports !== 'undefined') {
 })();
 
 /**
+ * LazyChartLoader.js
+ */
+(function () {
+    "use strict";
+
+    /**
+     * This class is used for manage Chart loading. This class limits the number of graphs
+     * that make queries simultaneously. 
+     *
+     * @constructor
+     * @param maxParallelsCharts
+     *            the number of graphs that are loaded simultaneously
+     */
+
+    LazyChartLoader = function (maxParallelsCharts) {
+        this.maxParallelsCharts = maxParallelsCharts;
+        this.activeCall = 0;
+        this.chartQueue = [];
+    };
+
+    LazyChartLoader.prototype = {
+        constructor: LazyChartLoader,
+
+        addChart: function (chart) {
+            this.chartQueue.push(chart);
+            this.__checkQueue();
+        },
+
+        __onCompleteOrFailure: function () {
+            this.activeCall--;
+            this.__checkQueue();
+        },
+
+        __onChartUpdate: function (updatePromise) {
+            updatePromise.then(
+                this.__onCompleteOrFailure.bind(this),
+                this.__onCompleteOrFailure.bind(this)
+            );
+        },
+
+        __checkQueue: function () {
+            if (this.chartQueue.length && this.activeCall <= this.maxParallelsCharts) {
+                var chart = this.chartQueue.shift();
+                if (!chart) {
+                    return;
+                }
+                this.activeCall++;
+                chart.onUpdate = this.__onChartUpdate.bind(this);
+                chart.update();
+            }
+        }
+    }
+})();
+
+/**
  * Chart.js
  * main chart object
  */
@@ -1383,7 +1439,7 @@ if (typeof exports !== 'undefined') {
         [31536000000, '10d-avg']  // 1 Year
     ];
 
-
+    var lazyLoader = new LazyChartLoader(30);
     Chart = function (name, config) {
         this.name = name;
         this.config = config;
@@ -1467,7 +1523,7 @@ if (typeof exports !== 'undefined') {
             if (this.request.metrics === undefined) {
                 debug.__warn('Chart configuration contains no metric sepcifications. No data will be displayed.');
             }
-            this.update();
+            lazyLoader.addChart(this);
         } catch (x) {
             debug.__error(x);
             this.__showError(x);


### PR DESCRIPTION
LazyChartLoader is used for manage Chart loading. This class limits the number of graphs that make queries simultaneously.
It is very useful when there are a lot of charts in the same page (every chart requests several queries).